### PR TITLE
Add num_micro_batches option in interface implementations.

### DIFF
--- a/docs/source/expconfig.rst
+++ b/docs/source/expconfig.rst
@@ -56,7 +56,7 @@ recursively with command line arguments.
 
 .. autoclass:: ParallelismConfig
 
-.. autoclass:: AllocationConfig
+.. autoclass:: MFCConfig
 
 .. autoclass:: ReaLModelConfig
 

--- a/examples/new_algorithms/grpo/grpo_exp.py
+++ b/examples/new_algorithms/grpo/grpo_exp.py
@@ -15,11 +15,7 @@ from realhf.api.core.config import (
 from realhf.api.core.dfg import MFCDef
 from realhf.api.core.model_api import register_interface
 from realhf.api.quickstart.dataset import PromptOnlyDatasetConfig
-from realhf.api.quickstart.device_mesh import (
-    AllocationConfig,
-    DeviceMesh,
-    RPCAllocation,
-)
+from realhf.api.quickstart.device_mesh import DeviceMesh, MFCConfig, RPCAllocation
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig, ParallelismConfig
 from realhf.experiments.common.common import CommonExperimentConfig
@@ -39,10 +35,10 @@ class GRPOConfig(CommonExperimentConfig):
     rew: ModelTrainEvalConfig = dataclasses.field(default_factory=ModelTrainEvalConfig)
 
     # for manual allocation only
-    actor_train: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
-    actor_gen: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
-    rew_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
-    ref_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+    actor_train: MFCConfig = dataclasses.field(default_factory=MFCConfig)
+    actor_gen: MFCConfig = dataclasses.field(default_factory=MFCConfig)
+    rew_inf: MFCConfig = dataclasses.field(default_factory=MFCConfig)
+    ref_inf: MFCConfig = dataclasses.field(default_factory=MFCConfig)
 
     dataset: PromptOnlyDatasetConfig = dataclasses.field(
         default_factory=PromptOnlyDatasetConfig
@@ -50,11 +46,6 @@ class GRPOConfig(CommonExperimentConfig):
 
     ppo: PPOHyperparameters = dataclasses.field(default_factory=PPOHyperparameters)
     group_size: int = 4
-
-    actor_train_n_mbs: int = 1
-    actor_gen_n_mbs: int = 1
-    rew_inf_n_mbs: int = 1
-    ref_inf_n_mbs: int = 1
 
     def __post_init__(self):
 
@@ -116,7 +107,7 @@ class GRPOConfig(CommonExperimentConfig):
         rollout = MFCDef(
             name=f"actor_gen",
             model_name="actor",
-            n_mbs=self.actor_gen_n_mbs,
+            n_mbs=self.actor_gen.n_mbs,
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -136,7 +127,7 @@ class GRPOConfig(CommonExperimentConfig):
         inf_reward = MFCDef(
             name=f"rew_inf",
             model_name="reward",
-            n_mbs=self.rew_inf_n_mbs,
+            n_mbs=self.rew_inf.n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=rw_interface,
             model_type=self.rew.type,
@@ -154,7 +145,7 @@ class GRPOConfig(CommonExperimentConfig):
         inf_ref_logits = MFCDef(
             name=f"ref_inf",
             model_name="ref",
-            n_mbs=self.ref_inf_n_mbs,
+            n_mbs=self.ref_inf.n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             model_type=self.ref.type,
             model_path=self.ref.path,
@@ -181,7 +172,7 @@ class GRPOConfig(CommonExperimentConfig):
         train_actor = MFCDef(
             name="actor_train",
             model_name="actor",
-            n_mbs=self.actor_train_n_mbs,
+            n_mbs=self.actor_train.n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             model_type=self.actor.type,
             model_path=self.actor.path,

--- a/examples/new_algorithms/grpo/grpo_exp.py
+++ b/examples/new_algorithms/grpo/grpo_exp.py
@@ -52,7 +52,7 @@ class GRPOConfig(CommonExperimentConfig):
     group_size: int = 4
 
     actor_train_n_mbs: int = 1
-    actor_gen_n_mbs: int = 1 
+    actor_gen_n_mbs: int = 1
     rew_inf_n_mbs: int = 1
     ref_inf_n_mbs: int = 1
 

--- a/examples/new_algorithms/grpo/grpo_exp.py
+++ b/examples/new_algorithms/grpo/grpo_exp.py
@@ -51,6 +51,11 @@ class GRPOConfig(CommonExperimentConfig):
     ppo: PPOHyperparameters = dataclasses.field(default_factory=PPOHyperparameters)
     group_size: int = 4
 
+    actor_train_n_mbs: int = 1
+    actor_gen_n_mbs: int = 1 
+    rew_inf_n_mbs: int = 1
+    ref_inf_n_mbs: int = 1
+
     def __post_init__(self):
 
         self.ppo_kwargs = dict(
@@ -111,6 +116,7 @@ class GRPOConfig(CommonExperimentConfig):
         rollout = MFCDef(
             name=f"actor_gen",
             model_name="actor",
+            n_mbs=self.actor_gen_n_mbs,
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -130,6 +136,7 @@ class GRPOConfig(CommonExperimentConfig):
         inf_reward = MFCDef(
             name=f"rew_inf",
             model_name="reward",
+            n_mbs=self.rew_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=rw_interface,
             model_type=self.rew.type,
@@ -147,6 +154,7 @@ class GRPOConfig(CommonExperimentConfig):
         inf_ref_logits = MFCDef(
             name=f"ref_inf",
             model_name="ref",
+            n_mbs=self.ref_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             model_type=self.ref.type,
             model_path=self.ref.path,
@@ -173,6 +181,7 @@ class GRPOConfig(CommonExperimentConfig):
         train_actor = MFCDef(
             name="actor_train",
             model_name="actor",
+            n_mbs=self.actor_train_n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             model_type=self.actor.type,
             model_path=self.actor.path,

--- a/examples/new_algorithms/grpo/grpo_interface.py
+++ b/examples/new_algorithms/grpo/grpo_interface.py
@@ -165,7 +165,7 @@ class GRPOInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
     ) -> SequenceSample:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.nn.real_llm_generate import (
@@ -199,6 +199,7 @@ class GRPOInterface(model_api.ModelInterface):
             input_=grouped_input,
             tokenizer=model.tokenizer,
             gconfig=self.generation_config,
+            num_micro_batches=n_mbs,
         )
         if res is None:
             return None
@@ -278,7 +279,7 @@ class GRPOInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
     ) -> SequenceSample:
         from realhf.impl.model.utils.functional import (
             apply_logits_mask,
@@ -288,7 +289,7 @@ class GRPOInterface(model_api.ModelInterface):
         module = model.module
         module.eval()
 
-        logits = module.forward(input_=input_)
+        logits = module.forward(input_=input_, num_micro_batches=n_mbs)
         if logits is None:
             return None
 
@@ -306,7 +307,7 @@ class GRPOInterface(model_api.ModelInterface):
         res = SequenceSample(
             keys=["packed_ref_logprobs"],
             ids=input_.ids,
-            dtypes=dict(packed_ref_logprobs=torch.float16),
+            dtypes=dict(packed_ref_logprobs=logprobs.dtype),
             trailing_shapes=dict(packed_ref_logprobs=()),
             data=dict(packed_ref_logprobs=logprobs),
             seqlens=dict(
@@ -315,7 +316,7 @@ class GRPOInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.utils.functional import masked_normalization
         from realhf.impl.model.utils.ppo_functional import (
@@ -425,6 +426,7 @@ class GRPOInterface(model_api.ModelInterface):
                     early_stop_imp_ratio=self.early_stop_imp_ratio,
                     early_stop_kl=self.early_stop_kl,
                 ),
+                num_micro_batches=n_mbs,
             )
             if stats:
                 for k, v in stats.items():

--- a/examples/new_algorithms/grpo/grpo_interface.py
+++ b/examples/new_algorithms/grpo/grpo_interface.py
@@ -316,7 +316,9 @@ class GRPOInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
+    def train_step(
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
+    ) -> Dict:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.utils.functional import masked_normalization
         from realhf.impl.model.utils.ppo_functional import (

--- a/examples/new_algorithms/reinforce/reinforce_exp.py
+++ b/examples/new_algorithms/reinforce/reinforce_exp.py
@@ -45,6 +45,10 @@ class ReinforceConfig(CommonExperimentConfig):
         default_factory=AllocationConfig
     )
 
+    actor_train_n_mbs: int = 1
+    gen_n_mbs: int = 1
+    rew_inf_n_mbs: int =1
+
     dataset: PromptOnlyDatasetConfig = dataclasses.field(
         default_factory=PromptOnlyDatasetConfig
     )
@@ -105,6 +109,7 @@ class ReinforceConfig(CommonExperimentConfig):
         sample_gen = MFCDef(
             name="sample_gen",
             model_name="actor",
+            n_mbs=self.gen_n_mbs,
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -122,6 +127,7 @@ class ReinforceConfig(CommonExperimentConfig):
         greedy_gen = MFCDef(
             name="greedy_gen",
             model_name="actor",
+            n_mbs=self.gen_n_mbs,
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -139,6 +145,7 @@ class ReinforceConfig(CommonExperimentConfig):
         sample_rw = MFCDef(
             name="sample_rw",
             model_name="reward",
+            n_mbs=self.rew_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=rw_interface,
             model_type=self.rew.type,
@@ -152,6 +159,7 @@ class ReinforceConfig(CommonExperimentConfig):
             model_name="reward",
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=rw_interface,
+            n_mbs=self.rew_inf_n_mbs,
             model_type=self.rew.type,
             model_path=self.rew.path,
             input_keys=["greedy_packed_input_ids"],
@@ -164,6 +172,7 @@ class ReinforceConfig(CommonExperimentConfig):
         actor_train = MFCDef(
             name="actor_train",
             model_name="actor",
+            n_mbs=self.actor_train_n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             model_type=self.actor.type,
             model_path=self.actor.path,

--- a/examples/new_algorithms/reinforce/reinforce_exp.py
+++ b/examples/new_algorithms/reinforce/reinforce_exp.py
@@ -47,7 +47,7 @@ class ReinforceConfig(CommonExperimentConfig):
 
     actor_train_n_mbs: int = 1
     gen_n_mbs: int = 1
-    rew_inf_n_mbs: int =1
+    rew_inf_n_mbs: int = 1
 
     dataset: PromptOnlyDatasetConfig = dataclasses.field(
         default_factory=PromptOnlyDatasetConfig

--- a/examples/new_algorithms/reinforce/reinforce_interface.py
+++ b/examples/new_algorithms/reinforce/reinforce_interface.py
@@ -88,7 +88,7 @@ class ReinforceInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample,n_mbs=None,
     ) -> SequenceSample:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.nn.real_llm_generate import (
@@ -104,6 +104,7 @@ class ReinforceInterface(model_api.ModelInterface):
             input_=input_,
             tokenizer=model.tokenizer,
             gconfig=self.generation_config,
+            num_micro_batches=n_mbs,
         )
         if res is None:
             return None
@@ -151,7 +152,7 @@ class ReinforceInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.utils.functional import masked_normalization
         from realhf.impl.model.utils.ppo_functional import (
@@ -222,6 +223,7 @@ class ReinforceInterface(model_api.ModelInterface):
             input_=input_,
             version_steps=model.version.global_step,
             loss_fn=_reinforce_loss_from_model_outputs,
+            num_micro_batches=n_mbs,
         )
 
         model.inc_version()

--- a/examples/new_algorithms/reinforce/reinforce_interface.py
+++ b/examples/new_algorithms/reinforce/reinforce_interface.py
@@ -88,7 +88,10 @@ class ReinforceInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample,n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.nn.real_llm_generate import (
@@ -152,7 +155,9 @@ class ReinforceInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
+    def train_step(
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
+    ) -> Dict:
         # NOTE: import here to avoid cuda initialization
         from realhf.impl.model.utils.functional import masked_normalization
         from realhf.impl.model.utils.ppo_functional import (

--- a/examples/scripts/local/sft.sh
+++ b/examples/scripts/local/sft.sh
@@ -38,7 +38,7 @@ python3 -m realhf.apps.quickstart sft \
     dataset.train_path=.data/sft_pos-train.jsonl \
     dataset.valid_path=.data/sft_pos-train.jsonl \
     dataset.max_seqlen=1024 \
-    dataset.train_bs_n_seqs=512 \
+    dataset.train_bs_n_seqs=2048 \
     dataset.valid_bs_n_seqs=512 \
     allocation_mode=manual \
     n_nodes=1 \

--- a/realhf/__init__.py
+++ b/realhf/__init__.py
@@ -14,7 +14,7 @@ from .api.quickstart.dataset import (
     PromptAnswerDatasetConfig,
     PromptOnlyDatasetConfig,
 )
-from .api.quickstart.device_mesh import AllocationConfig
+from .api.quickstart.device_mesh import MFCConfig
 from .api.quickstart.model import (
     ModelTrainEvalConfig,
     OptimizerConfig,

--- a/realhf/api/core/dfg.py
+++ b/realhf/api/core/dfg.py
@@ -51,6 +51,8 @@ class MFCDef:
 
     Fields starting with an underscore will be filled automatically.
 
+    NOTE: in implementation of ReaL, term RPC also refers to MFC.
+
     :param name: The unique identifier of this model function call.
     :type name: str
     :param n_seqs: The number of sequences to be processed in a batch.

--- a/realhf/api/core/dfg.py
+++ b/realhf/api/core/dfg.py
@@ -76,6 +76,11 @@ class MFCDef:
     :param output_key_remap: Remap output keys to let MFC recognize them.
         Keys are identifiers known to the interface and values are ``output_keys``.
     :type output_key_remap: Dict[str, str]
+    :param n_mbs: Number of micro batches when executing this MFC.
+        If None, defaults to 1 if pipeline parallelism is disabled,
+        defaults to 2 * pp_size for train_step and pp_size for generate/inference
+        if pipeline parallelism is enabled.
+    :type n_mbs: int
     :param balanced_dp: Whether to balance the data parallelism such that
         each DP rank will get exactly n_seqs // dp_size sequences.
         If set to False, ReaL will do partition according to the number of tokens.
@@ -113,6 +118,7 @@ class MFCDef:
     output_keys: Tuple = dataclasses.field(default_factory=tuple)
     output_key_remap: Dict[str, str] = dataclasses.field(default_factory=lambda: {})
 
+    n_mbs: Optional[int] = None
     balanced_dp: bool = False
     log_return_value: bool = False
 

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -78,21 +78,24 @@ class ReaLMoEConfig:
     :param top_k: The number of experts to route per-token, can be also
         interpreted as the `top-k` routing parameter.
     :type top_k: int
-    :param routing_type: The load balancing type for the MoE router.
-        Can be "aux_loss", "sinkhorn", or "none".
+    :param routing_type: The load balancing type for the MoE router. Can
+        be "aux_loss", "sinkhorn", or "none".
     :type routing_type: str
-    :param aux_loss_coeff: The coefficient for the auxiliary loss.
-        Only effective when routing_type="aux_loss".
+    :param aux_loss_coeff: The coefficient for the auxiliary loss. Only
+        effective when routing_type="aux_loss".
     :type aux_loss_coeff: float
-    :param capacity_factor: The capacity factor of each expert.
-        An expert will drop tokens if the number of tokens exceeds capacity_factor * (num_tokens / num_experts).
-        Drop nothing when capacity_factor is None.
+    :param capacity_factor: The capacity factor of each expert. An
+        expert will drop tokens if the number of tokens exceeds
+        capacity_factor * (num_tokens / num_experts). Drop nothing when
+        capacity_factor is None.
     :type capacity_factor: float
-    :param pad_to_capacity: Whether to pad the input to the capacity of the expert.
+    :param pad_to_capacity: Whether to pad the input to the capacity of
+        the expert.
     :type pad_to_capacity: bool
-    :param token_drop_policy: The token drop policy for the MoE. Can be either "prob" or "position".
-        If "prob", the tokens with the lowest probabilities will be dropped.
-        If "position", tokens at the end of each batch will be dropped.
+    :param token_drop_policy: The token drop policy for the MoE. Can be
+        either "prob" or "position". If "prob", the tokens with the
+        lowest probabilities will be dropped. If "position", tokens at
+        the end of each batch will be dropped.
     :type token_drop_policy: str
     :param z_loss_coeff: The coefficient for the z-loss.
     :type z_loss_coeff: float

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -303,8 +303,9 @@ class ModelInterface(abc.ABC):
         pass
 
     def evaluate(
-        self, model: Model, eval_dataloader: torch.utils.data.DataLoader
+        self, model: Model, eval_dataloader: torch.utils.data.DataLoader,
     ) -> Dict:
+        # NOTE: No n_mbs here because the batch size can be configured in the dataloader.
         return {}
 
     def inference(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> SequenceSample:

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -140,10 +140,6 @@ class ReaLModelConfig:
     :type sliding_window: Optional[int]
     :param is_critic: Whether the model is a critic model.
     :type is_critic: bool
-    :param gradient_accumulation_fusion: Whether to fuse
-        gradient accumulation in Megatron.
-        Currently not supported.
-    :type gradient_accumulation_fusion: bool
     """
 
     ### Architectural configurations. ###
@@ -183,9 +179,6 @@ class ReaLModelConfig:
     sliding_window: Optional[int] = None
     # Whether it is a critic/reward model that outputs scores.
     is_critic: bool = False
-
-    ### Running configurations. ###
-    gradient_accumulation_fusion: bool = False
 
     def __post_init__(self):
         if self.is_critic and self.tied_embedding:
@@ -314,13 +307,13 @@ class ModelInterface(abc.ABC):
     ) -> Dict:
         return {}
 
-    def inference(self, model: Model, data: SequenceSample) -> SequenceSample:
+    def inference(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> SequenceSample:
         raise NotImplementedError()
 
-    def generate(self, model: Model, data: SequenceSample) -> SequenceSample:
+    def generate(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> SequenceSample:
         raise NotImplementedError()
 
-    def train_step(self, model: Model, data: SequenceSample) -> Dict:
+    def train_step(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> Dict:
         raise NotImplementedError()
 
 

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -303,18 +303,26 @@ class ModelInterface(abc.ABC):
         pass
 
     def evaluate(
-        self, model: Model, eval_dataloader: torch.utils.data.DataLoader,
+        self,
+        model: Model,
+        eval_dataloader: torch.utils.data.DataLoader,
     ) -> Dict:
         # NOTE: No n_mbs here because the batch size can be configured in the dataloader.
         return {}
 
-    def inference(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> SequenceSample:
+    def inference(
+        self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None
+    ) -> SequenceSample:
         raise NotImplementedError()
 
-    def generate(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> SequenceSample:
+    def generate(
+        self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None
+    ) -> SequenceSample:
         raise NotImplementedError()
 
-    def train_step(self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None) -> Dict:
+    def train_step(
+        self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None
+    ) -> Dict:
         raise NotImplementedError()
 
 

--- a/realhf/api/quickstart/device_mesh.py
+++ b/realhf/api/quickstart/device_mesh.py
@@ -293,11 +293,11 @@ class RPCAllocation:
 class MFCConfig:
     """Configuration for one MFC.
 
-    :param n_mbs: Number of micro batches when executing this MFC.
-        See MFCDef for details.
+    :param n_mbs: Number of micro batches when executing this MFC. See
+        MFCDef for details.
     :type n_mbs: Optional[int]
-    :param parallel: Parallelism strategy configuration.
-        Only used for manual allocation.
+    :param parallel: Parallelism strategy configuration. Only used for
+        manual allocation.
     :type parallel: ParallelismConfig
     :param device_mesh: String representation for device mesh. If it is
         composed of multiple nodes, it should be in the form of slurm
@@ -305,8 +305,8 @@ class MFCConfig:
         on a single node, we restrict it occupies 1, 2, 4, or 8
         contiguous GPUs in the node. In this case, the string
         representation is similar to the MPI hostfile, e.g.,
-        "node01:0,1,2,3" for the first 4 GPUs on node01.
-        Only used for manual allocation.
+        "node01:0,1,2,3" for the first 4 GPUs on node01. Only used for
+        manual allocation.
     :type device_mesh: str
     """
 

--- a/realhf/api/quickstart/device_mesh.py
+++ b/realhf/api/quickstart/device_mesh.py
@@ -290,10 +290,14 @@ class RPCAllocation:
 
 
 @dataclasses.dataclass
-class AllocationConfig:
-    """Allocation configuration for one RPC, used for manual allocation.
+class MFCConfig:
+    """Configuration for one MFC.
 
+    :param n_mbs: Number of micro batches when executing this MFC.
+        See MFCDef for details.
+    :type n_mbs: Optional[int]
     :param parallel: Parallelism strategy configuration.
+        Only used for manual allocation.
     :type parallel: ParallelismConfig
     :param device_mesh: String representation for device mesh. If it is
         composed of multiple nodes, it should be in the form of slurm
@@ -302,8 +306,10 @@ class AllocationConfig:
         contiguous GPUs in the node. In this case, the string
         representation is similar to the MPI hostfile, e.g.,
         "node01:0,1,2,3" for the first 4 GPUs on node01.
+        Only used for manual allocation.
     :type device_mesh: str
     """
 
+    n_mbs: Optional[int] = None
     parallel: ParallelismConfig = dataclasses.field(default_factory=ParallelismConfig)
     device_mesh: Optional[str] = None

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -490,12 +490,14 @@ def clear_global_stats_tracker():
 def log_global_stats_tracker(
     return_dict: bool = True, clear_stats_after_logging: bool = True
 ):
-    """Log the global stats tracker and optionally return the stats as a dictionary.
-    This method is expected to be called in interface implementations.
+    """Log the global stats tracker and optionally return the stats as a
+    dictionary. This method is expected to be called in interface
+    implementations.
 
     :param return_dict: Whether to return the stats as a dictionary.
     :type return_dict: bool
-    :param clear_stats_after_logging: Whether to clear the stats after logging.
+    :param clear_stats_after_logging: Whether to clear the stats after
+        logging.
     :type clear_stats_after_logging: bool
     """
     if _model_name is None:

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -220,6 +220,7 @@ def use_te_impl() -> bool:
 def sequence_parallel() -> bool:
     return grid().topology().sequence_parallel
 
+
 def gradient_accumulation_fusion() -> bool:
     # FIXME: change it to be an option since ds cannot use it
     _grad_accum_fusion_available = True
@@ -229,6 +230,7 @@ def gradient_accumulation_fusion() -> bool:
         _grad_accum_fusion_available = False
     print(">>>>>>>>>>>>>>>>>>>>>>>>>>", _grad_accum_fusion_available)
     return _grad_accum_fusion_available
+
 
 def max_prompt_len() -> int:
     return grid().topology().max_prompt_len

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -220,6 +220,15 @@ def use_te_impl() -> bool:
 def sequence_parallel() -> bool:
     return grid().topology().sequence_parallel
 
+def gradient_accumulation_fusion() -> bool:
+    # FIXME: change it to be an option since ds cannot use it
+    _grad_accum_fusion_available = True
+    try:
+        import fused_weight_gradient_mlp_cuda
+    except ImportError:
+        _grad_accum_fusion_available = False
+    print(">>>>>>>>>>>>>>>>>>>>>>>>>>", _grad_accum_fusion_available)
+    return _grad_accum_fusion_available
 
 def max_prompt_len() -> int:
     return grid().topology().max_prompt_len

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -227,7 +227,9 @@ def gradient_accumulation_fusion() -> bool:
         import fused_weight_gradient_mlp_cuda
     except ImportError:
         _grad_accum_fusion_available = False
-    return _grad_accum_fusion_available and grid().topology().gradient_accumulation_fusion
+    return (
+        _grad_accum_fusion_available and grid().topology().gradient_accumulation_fusion
+    )
 
 
 def max_prompt_len() -> int:

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -222,14 +222,12 @@ def sequence_parallel() -> bool:
 
 
 def gradient_accumulation_fusion() -> bool:
-    # FIXME: change it to be an option since ds cannot use it
     _grad_accum_fusion_available = True
     try:
         import fused_weight_gradient_mlp_cuda
     except ImportError:
         _grad_accum_fusion_available = False
-    print(">>>>>>>>>>>>>>>>>>>>>>>>>>", _grad_accum_fusion_available)
-    return _grad_accum_fusion_available
+    return _grad_accum_fusion_available and grid().topology().gradient_accumulation_fusion
 
 
 def max_prompt_len() -> int:

--- a/realhf/base/testing.py
+++ b/realhf/base/testing.py
@@ -180,6 +180,7 @@ def init_global_constants(
     msid2mwid=None,
     sequence_parallel=False,
     gradient_checkpointing=True,
+    gradient_accumulation_fusion=False,
     max_prompt_len=None,
 ):
     model_name = model_name if model_name is not None else MODEL_NAME
@@ -191,6 +192,7 @@ def init_global_constants(
             num_pp=num_pp,
             sequence_parallel=sequence_parallel,
             gradient_checkpointing=gradient_checkpointing,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
             max_prompt_len=max_prompt_len,
         )
         ws = num_dp * num_mp * num_pp

--- a/realhf/base/topology.py
+++ b/realhf/base/topology.py
@@ -293,6 +293,7 @@ class PipeModelDataParallelTopology(ProcessTopology):
         num_dp: int,
         sequence_parallel: bool,
         gradient_checkpointing: bool,
+        gradient_accumulation_fusion: bool,
         max_prompt_len: Optional[int] = None,
     ):
         super().__init__(axes=["pipe", "data", "model"], dims=[num_pp, num_dp, num_mp])
@@ -300,6 +301,7 @@ class PipeModelDataParallelTopology(ProcessTopology):
         self.sequence_parallel = sequence_parallel
         self.gradient_checkpointing = gradient_checkpointing
         self.max_prompt_len = max_prompt_len
+        self.gradient_accumulation_fusion = gradient_accumulation_fusion
 
 
 class ParallelGrid:

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -425,6 +425,7 @@ class CommonExperimentConfig(Experiment):
                         )
                         else None
                     ),
+                    gradient_accumulation_fusion=model_cfg.backend == "megatron",
                 )
 
                 if any(

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -28,8 +28,8 @@ from realhf.api.core.system_api import (
     TasksGroup,
 )
 from realhf.api.quickstart.device_mesh import (
-    AllocationConfig,
     DeviceMesh,
+    MFCConfig,
     RPCAllocation,
     make_device_mesh_from_name,
 )
@@ -184,11 +184,13 @@ class CommonExperimentConfig(Experiment):
 
         Note that model function call names are different from model
         names. Should be implemented in all subclasses.
+
+        NOTE: in implementation of ReaL, term RPC also refers to MFC.
         """
         raise NotImplementedError(f"rpcs is not implemented in {self.__class__}")
 
     @property
-    def allocations(self) -> Dict[str, AllocationConfig]:
+    def allocations(self) -> Dict[str, MFCConfig]:
         """The allocation configuration for each model function call.
 
         A dictionary mapping MFC names to its allocation configuration.

--- a/realhf/experiments/common/dpo_exp.py
+++ b/realhf/experiments/common/dpo_exp.py
@@ -10,7 +10,7 @@ from realhf.api.core.config import (
 )
 from realhf.api.core.dfg import MFCDef
 from realhf.api.quickstart.dataset import PairedComparisonDatasetConfig
-from realhf.api.quickstart.device_mesh import AllocationConfig
+from realhf.api.quickstart.device_mesh import MFCConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig
 from realhf.experiments.common.common import CommonExperimentConfig
@@ -44,13 +44,13 @@ class DPOConfig(CommonExperimentConfig):
     :type ref: ModelTrainEvalConfig
     :param actor_train: Device allocation and parallelism configuration for
         running training on the primary LLM.
-    :type actor_train: AllocationConfig
+    :type actor_train: MFCConfig
     :param ref_inf: Device allocation and parallelism configuration for
         running inference on the reference LLM.
         This can be different from the training allocation.
         A large data parallel degree with additional pipelining
         can be faster for inference.
-    :type ref_inf: AllocationConfig
+    :type ref_inf: MFCConfig
     :param dataset: Dataset configuration. The same for reward modeling.
     :type dataset: PairedComparisonDatasetConfig
     :param beta: KL regularization coefficient.
@@ -69,16 +69,13 @@ class DPOConfig(CommonExperimentConfig):
     )
     ref: ModelTrainEvalConfig = dataclasses.field(default_factory=ModelTrainEvalConfig)
 
-    actor_train: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
-    ref_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+    actor_train: MFCConfig = dataclasses.field(default_factory=MFCConfig)
+    ref_inf: MFCConfig = dataclasses.field(default_factory=MFCConfig)
 
     dataset: PairedComparisonDatasetConfig = dataclasses.field(
         default_factory=PairedComparisonDatasetConfig
     )
     beta: float = 0.1
-
-    actor_train_n_mbs: int = 1
-    ref_inf_n_mbs: int = 1
 
     def __post_init__(self):
         assert (
@@ -102,7 +99,7 @@ class DPOConfig(CommonExperimentConfig):
         )
         ref_inf = MFCDef(
             name="ref_inf",
-            n_mbs=self.ref_inf_n_mbs,
+            n_mbs=self.ref_inf.n_mbs,
             model_name=ModelName("ref", 0),
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=ref_interface,
@@ -117,7 +114,7 @@ class DPOConfig(CommonExperimentConfig):
         )
         dpo = MFCDef(
             name="actor_train",
-            n_mbs=self.actor_train_n_mbs,
+            n_mbs=self.actor_train.n_mbs,
             model_name=ModelName("actor", 0),
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=interface,

--- a/realhf/experiments/common/dpo_exp.py
+++ b/realhf/experiments/common/dpo_exp.py
@@ -55,6 +55,10 @@ class DPOConfig(CommonExperimentConfig):
     :type dataset: PairedComparisonDatasetConfig
     :param beta: KL regularization coefficient.
     :type beta: float
+    :param actor_train_n_mbs: Number of microbatches for training the primary LLM.
+    :type actor_train_n_mbs: int
+    :param ref_inf_n_mbs: Number of microbatches for inference on the reference LLM.
+    :type ref_inf_n_mbs: int
     """
 
     is_sft_lora: bool = False
@@ -72,6 +76,9 @@ class DPOConfig(CommonExperimentConfig):
         default_factory=PairedComparisonDatasetConfig
     )
     beta: float = 0.1
+
+    actor_train_n_mbs: int = 1
+    ref_inf_n_mbs: int = 1
 
     def __post_init__(self):
         assert (
@@ -95,6 +102,7 @@ class DPOConfig(CommonExperimentConfig):
         )
         ref_inf = MFCDef(
             name="ref_inf",
+            n_mbs=self.ref_inf_n_mbs,
             model_name=ModelName("ref", 0),
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=ref_interface,
@@ -109,6 +117,7 @@ class DPOConfig(CommonExperimentConfig):
         )
         dpo = MFCDef(
             name="actor_train",
+            n_mbs=self.actor_train_n_mbs,
             model_name=ModelName("actor", 0),
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=interface,

--- a/realhf/experiments/common/gen_exp.py
+++ b/realhf/experiments/common/gen_exp.py
@@ -9,7 +9,7 @@ from realhf.api.core.config import (
 from realhf.api.core.dfg import MFCDef
 from realhf.api.core.model_api import GenerationHyperparameters
 from realhf.api.quickstart.dataset import PromptOnlyDatasetConfig
-from realhf.api.quickstart.device_mesh import AllocationConfig
+from realhf.api.quickstart.device_mesh import MFCConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig
 from realhf.experiments.common.common import CommonExperimentConfig
@@ -29,7 +29,7 @@ class GenerationConfig(CommonExperimentConfig):
     :param dataset: Dataset configuration
     :type dataset: PromptOnlyDatasetConfig
     :param allocation: Device allocation and parallelism configuration.
-    :type allocation: AllocationConfig
+    :type allocation: MFCConfig
     """
 
     model: ModelTrainEvalConfig = dataclasses.field(
@@ -41,7 +41,7 @@ class GenerationConfig(CommonExperimentConfig):
     dataset: PromptOnlyDatasetConfig = dataclasses.field(
         default_factory=PromptOnlyDatasetConfig
     )
-    allocation: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+    allocation: MFCConfig = dataclasses.field(default_factory=MFCConfig)
 
     @property
     def models(self):
@@ -56,7 +56,7 @@ class GenerationConfig(CommonExperimentConfig):
         )
         gen = MFCDef(
             name="gen",
-            n_mbs=1,
+            n_mbs=self.allocation.n_mbs,
             model_name=ModelName("default", 0),
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.model,

--- a/realhf/experiments/common/gen_exp.py
+++ b/realhf/experiments/common/gen_exp.py
@@ -56,6 +56,7 @@ class GenerationConfig(CommonExperimentConfig):
         )
         gen = MFCDef(
             name="gen",
+            n_mbs=1,
             model_name=ModelName("default", 0),
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.model,

--- a/realhf/experiments/common/ppo_exp.py
+++ b/realhf/experiments/common/ppo_exp.py
@@ -188,6 +188,18 @@ class PPOConfig(CommonExperimentConfig):
     :type dataset: PromptOnlyDatasetConfig
     :param ppo: Configuration for the PPO algorithm.
     :type ppo: PPOHyperparameters
+    :param actor_train_n_mbs: Number of minibatches for TrainActor.
+    :type actor_train_n_mbs: int
+    :param critic_train_n_mbs: Number of minibatches for TrainCritic.
+    :type critic_train_n_mbs: int
+    :param actor_gen_n_mbs: Number of minibatches for Rollout.
+    :type actor_gen_n_mbs: int
+    :param critic_inf_n_mbs: Number of minibatches for InfValues.
+    :type critic_inf_n_mbs: int
+    :param rew_inf_n_mbs: Number of minibatches for InfReward.
+    :type rew_inf_n_mbs: int
+    :param ref_inf_n_mbs: Number of minibatches for InfRef.
+    :type ref_inf_n_mbs: int
     """
 
     is_sft_lora: bool = False
@@ -212,6 +224,13 @@ class PPOConfig(CommonExperimentConfig):
     critic_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
     rew_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
     ref_inf: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+
+    actor_train_n_mbs: int = 1
+    critic_train_n_mbs: int = 1
+    actor_gen_n_mbs: int = 1
+    critic_inf_n_mbs: int = 1
+    rew_inf_n_mbs: int = 1
+    ref_inf_n_mbs: int = 1
 
     dataset: PromptOnlyDatasetConfig = dataclasses.field(
         default_factory=PromptOnlyDatasetConfig
@@ -292,6 +311,7 @@ class PPOConfig(CommonExperimentConfig):
         rollout = MFCDef(
             name="actor_gen",
             model_name="actor",
+            n_mbs=self.actor_gen_n_mbs,
             interface_type=ModelInterfaceType.GENERATE,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -311,6 +331,7 @@ class PPOConfig(CommonExperimentConfig):
         inf_reward = MFCDef(
             name="rew_inf",
             model_name="reward",
+            n_mbs=self.rew_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=rw_interface,
             model_type=self.rew.type,
@@ -328,6 +349,7 @@ class PPOConfig(CommonExperimentConfig):
         inf_ref_logits = MFCDef(
             name="ref_inf",
             model_name="ref",
+            n_mbs=self.ref_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             model_type=self.ref.type,
             model_path=self.ref.path,
@@ -340,6 +362,7 @@ class PPOConfig(CommonExperimentConfig):
         inf_values = MFCDef(
             name="critic_inf",
             model_name="critic",
+            n_mbs=self.critic_inf_n_mbs,
             interface_type=ModelInterfaceType.INFERENCE,
             interface_impl=critic_interface,
             model_type=self.critic.type,
@@ -364,6 +387,7 @@ class PPOConfig(CommonExperimentConfig):
         train_actor = MFCDef(
             name="actor_train",
             model_name="actor",
+            n_mbs=self.actor_train_n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             model_type=self.actor.type,
             model_path=self.actor.path,
@@ -376,6 +400,7 @@ class PPOConfig(CommonExperimentConfig):
         train_critic = MFCDef(
             name="critic_train",
             model_name="critic",
+            n_mbs=self.critic_train_n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=critic_interface,
             model_type=self.critic.type,

--- a/realhf/experiments/common/rw_exp.py
+++ b/realhf/experiments/common/rw_exp.py
@@ -10,7 +10,7 @@ from realhf.api.core.config import (
 )
 from realhf.api.core.dfg import MFCDef
 from realhf.api.quickstart.dataset import PairedComparisonDatasetConfig
-from realhf.api.quickstart.device_mesh import AllocationConfig
+from realhf.api.quickstart.device_mesh import MFCConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig
 from realhf.experiments.common.common import CommonExperimentConfig
@@ -34,7 +34,7 @@ class RWConfig(CommonExperimentConfig):
     :param model: Model runtime configuration.
     :type model: ModelTrainEvalConfig
     :param allocation: Device allocation and parallelism configuration.
-    :type allocation: AllocationConfig
+    :type allocation: MFCConfig
     :param dataset: Dataset configuration.
     :type dataset: PairedComparisonDatasetConfig
     :param n_mbs: Number of microbatches.
@@ -46,12 +46,11 @@ class RWConfig(CommonExperimentConfig):
     model: ModelTrainEvalConfig = dataclasses.field(
         default_factory=ModelTrainEvalConfig
     )
-    allocation: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+    allocation: MFCConfig = dataclasses.field(default_factory=MFCConfig)
 
     dataset: PairedComparisonDatasetConfig = dataclasses.field(
         default_factory=PairedComparisonDatasetConfig
     )
-    n_mbs: int = 1
 
     def __post_init__(self):
         assert (
@@ -70,7 +69,7 @@ class RWConfig(CommonExperimentConfig):
         interface = ModelInterfaceAbstraction("paired_rw")
         rpc = MFCDef(
             name="rwTrain",
-            n_mbs=self.n_mbs,
+            n_mbs=self.allocation.n_mbs,
             model_name=ModelName("default", 0),
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=interface,

--- a/realhf/experiments/common/rw_exp.py
+++ b/realhf/experiments/common/rw_exp.py
@@ -37,6 +37,8 @@ class RWConfig(CommonExperimentConfig):
     :type allocation: AllocationConfig
     :param dataset: Dataset configuration.
     :type dataset: PairedComparisonDatasetConfig
+    :param n_mbs: Number of microbatches.
+    :type n_mbs: int
     """
 
     is_sft_lora: bool = False
@@ -49,6 +51,7 @@ class RWConfig(CommonExperimentConfig):
     dataset: PairedComparisonDatasetConfig = dataclasses.field(
         default_factory=PairedComparisonDatasetConfig
     )
+    n_mbs: int = 1
 
     def __post_init__(self):
         assert (
@@ -67,6 +70,7 @@ class RWConfig(CommonExperimentConfig):
         interface = ModelInterfaceAbstraction("paired_rw")
         rpc = MFCDef(
             name="rwTrain",
+            n_mbs=self.n_mbs,
             model_name=ModelName("default", 0),
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=interface,

--- a/realhf/experiments/common/sft_exp.py
+++ b/realhf/experiments/common/sft_exp.py
@@ -9,7 +9,7 @@ from realhf.api.core.config import (
 )
 from realhf.api.core.dfg import MFCDef
 from realhf.api.quickstart.dataset import PromptAnswerDatasetConfig
-from realhf.api.quickstart.device_mesh import AllocationConfig
+from realhf.api.quickstart.device_mesh import MFCConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig
 from realhf.experiments.common.common import CommonExperimentConfig
@@ -25,7 +25,7 @@ class SFTConfig(CommonExperimentConfig):
     :param model: Model runtime configuration.
     :type model: ModelTrainEvalConfig
     :param allocation: Device allocation and parallelism configuration.
-    :type allocation: AllocationConfig
+    :type allocation: MFCConfig
     :param dataset: Dataset configuration
     :type dataset: PromptAnswerDatasetConfig
     :param n_mbs: Number of microbatches.
@@ -35,11 +35,10 @@ class SFTConfig(CommonExperimentConfig):
     model: ModelTrainEvalConfig = dataclasses.field(
         default_factory=ModelTrainEvalConfig
     )
-    allocation: AllocationConfig = dataclasses.field(default_factory=AllocationConfig)
+    allocation: MFCConfig = dataclasses.field(default_factory=MFCConfig)
     dataset: PromptAnswerDatasetConfig = dataclasses.field(
         default_factory=PromptAnswerDatasetConfig
     )
-    n_mbs: int = 1
 
     @property
     def models(self):
@@ -52,7 +51,7 @@ class SFTConfig(CommonExperimentConfig):
         rpc = MFCDef(
             n_seqs=self.dataset.train_bs_n_seqs,
             name="trainDefault",
-            n_mbs=self.n_mbs,
+            n_mbs=self.allocation.n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=ModelInterfaceAbstraction("sft"),
             model_name="default",

--- a/realhf/experiments/common/sft_exp.py
+++ b/realhf/experiments/common/sft_exp.py
@@ -28,6 +28,8 @@ class SFTConfig(CommonExperimentConfig):
     :type allocation: AllocationConfig
     :param dataset: Dataset configuration
     :type dataset: PromptAnswerDatasetConfig
+    :param n_mbs: Number of microbatches.
+    :type n_mbs: int
     """
 
     model: ModelTrainEvalConfig = dataclasses.field(
@@ -37,6 +39,7 @@ class SFTConfig(CommonExperimentConfig):
     dataset: PromptAnswerDatasetConfig = dataclasses.field(
         default_factory=PromptAnswerDatasetConfig
     )
+    n_mbs: int = 1
 
     @property
     def models(self):
@@ -49,6 +52,7 @@ class SFTConfig(CommonExperimentConfig):
         rpc = MFCDef(
             n_seqs=self.dataset.train_bs_n_seqs,
             name="trainDefault",
+            n_mbs=self.n_mbs,
             interface_type=ModelInterfaceType.TRAIN_STEP,
             interface_impl=ModelInterfaceAbstraction("sft"),
             model_name="default",

--- a/realhf/experiments/common/utils.py
+++ b/realhf/experiments/common/utils.py
@@ -23,6 +23,7 @@ logger = logging.getLogger("Experiment Common Utils", "benchmark")
 def get_topo(
     parallel: ParallelismConfig,
     gradient_checkpointing: bool,
+    gradient_accumulation_fusion: bool,
     max_prompt_len: Optional[int] = None,
 ) -> PipeModelDataParallelTopology:
     return PipeModelDataParallelTopology(
@@ -32,6 +33,7 @@ def get_topo(
         sequence_parallel=parallel.use_sequence_parallel,
         gradient_checkpointing=gradient_checkpointing,
         max_prompt_len=max_prompt_len,
+        gradient_accumulation_fusion=gradient_accumulation_fusion,
     )
 
 

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -202,7 +202,7 @@ class ReaLDeepSpeedEngine:
     ):
         if constants.pipe_parallel_world_size() > 1:
             if num_micro_batches is not None:
-                if num_micro_batches > self.pipe_runner.default_train_mbs:
+                if num_micro_batches < self.pipe_runner.default_train_mbs:
                     logger.warning(
                         "When training with pipeline parallel, num micro batches should be "
                         "larger than 2 x num_pipeline_stages to avoid idle time. "

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -4,12 +4,15 @@ import math
 from typing import *
 
 import deepspeed
+import collections
 import torch
 import torch.distributed as dist
 import transformers
 from deepspeed.runtime import zero
 from deepspeed.runtime.bf16_optimizer import BF16_Optimizer
 from deepspeed.runtime.config import DeepSpeedConfig
+from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 from deepspeed.runtime.engine import (
     MEMORY_OPT_ALLREDUCE_SIZE,
     DeepSpeedEngine,
@@ -207,17 +210,29 @@ class ReaLDeepSpeedEngine:
                 num_micro_batches=num_micro_batches,
             )
         else:
-            # FIXME: num_micro_batches is ignored here
-            input_lens = torch.cat(input_.seqlens["packed_input_ids"], dim=0).cuda()
-            max_seqlen = int(max(input_lens))
-            cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-            model_output = self.ds_engine(
-                packed_input_ids=input_.data["packed_input_ids"],
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            ).logits
-            loss, stat = loss_fn(model_output, input_)
-            self.ds_engine.backward(loss)
+            if num_micro_batches is None:
+                num_micro_batches = 1
+            self.ds_engine._config.gradient_accumulation_steps = num_micro_batches
+            self.ds_engine.set_gradient_accumulation_boundary(False)
+            if isinstance(self.ds_engine.optimizer, (DeepSpeedZeroOptimizer, DeepSpeedZeroOptimizer_Stage3)):
+                self.ds_engine.optimizer.gradient_accumulation_steps = num_micro_batches
+
+            stat = collections.defaultdict(int)
+            for i, mb_input in enumerate(input_.split(num_micro_batches)):
+                if i == num_micro_batches - 1:
+                    self.ds_engine.set_gradient_accumulation_boundary(True)
+                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                max_seqlen = int(max(input_lens))
+                cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+                model_output = self.ds_engine(
+                    packed_input_ids=mb_input.data["packed_input_ids"],
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                ).logits
+                loss, _stat = loss_fn(model_output, mb_input)
+                self.ds_engine.backward(loss)
+                for k, v in _stat.items():
+                    stat[k] += v
             lr_kwargs = {"epoch": version_steps} if version_steps is not None else None
             self.ds_engine.step(lr_kwargs=lr_kwargs)
             return stat

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -202,9 +202,17 @@ class ReaLDeepSpeedEngine:
     ):
         if constants.pipe_parallel_world_size() > 1:
             if num_micro_batches is not None:
+                if num_micro_batches > self.pipe_runner.default_train_mbs:
+                    logger.warning(
+                        "When training with pipeline parallel, num micro batches should be "
+                        "larger than 2 x num_pipeline_stages to avoid idle time. "
+                        f"Setting num_micro_batches to {self.pipe_runner.default_train_mbs}"
+                    )
                 num_micro_batches = max(
                     num_micro_batches, self.pipe_runner.default_train_mbs
                 )
+            else:
+                num_micro_batches = self.pipe_runner.default_train_mbs
             instr_set = PipeTrainSetForDeepSpeed(self.ds_engine)
             return self.pipe_runner.train_batch(
                 instr_set=instr_set,

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -201,6 +201,8 @@ class ReaLDeepSpeedEngine:
         num_micro_batches: Optional[int] = None,
     ):
         if constants.pipe_parallel_world_size() > 1:
+            if num_micro_batches is not None:
+                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_train_mbs)
             instr_set = PipeTrainSetForDeepSpeed(self.ds_engine)
             return self.pipe_runner.train_batch(
                 instr_set=instr_set,

--- a/realhf/impl/model/backend/inference.py
+++ b/realhf/impl/model/backend/inference.py
@@ -84,6 +84,8 @@ class PipelinableInferenceEngine:
         num_micro_batches: Optional[int] = None,
     ):
         if constants.pipe_parallel_world_size() > 1:
+            if num_micro_batches is not None:
+                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
             return self.pipe_runner.eval_batch(
                 input_=input_,
                 loss_fn=loss_fn,
@@ -113,6 +115,8 @@ class PipelinableInferenceEngine:
         num_micro_batches: Optional[int] = None,
     ):
         if constants.pipe_parallel_world_size() > 1:
+            if num_micro_batches is not None:
+                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
             return self.pipe_runner.forward(
                 input_=input_,
                 num_micro_batches=num_micro_batches,
@@ -144,6 +148,8 @@ class PipelinableInferenceEngine:
         num_micro_batches: Optional[int] = None,
     ):
         if constants.pipe_parallel_world_size() > 1:
+            if num_micro_batches is not None:
+                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
             return self.pipe_runner.generate(
                 input_=input_,
                 num_micro_batches=num_micro_batches,

--- a/realhf/impl/model/backend/inference.py
+++ b/realhf/impl/model/backend/inference.py
@@ -1,10 +1,10 @@
+import collections
 import dataclasses
 from typing import *
 
 import torch
 import torch.distributed as dist
 import transformers
-import collections
 
 import realhf.api.core.model_api as model_api
 import realhf.base.constants as constants
@@ -85,7 +85,9 @@ class PipelinableInferenceEngine:
     ):
         if constants.pipe_parallel_world_size() > 1:
             if num_micro_batches is not None:
-                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
+                num_micro_batches = max(
+                    num_micro_batches, self.pipe_runner.default_inf_mbs
+                )
             return self.pipe_runner.eval_batch(
                 input_=input_,
                 loss_fn=loss_fn,
@@ -96,7 +98,9 @@ class PipelinableInferenceEngine:
                 num_micro_batches = 1
             stat = collections.defaultdict(int)
             for mb_input in input_.split(num_micro_batches):
-                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                input_lens = torch.cat(
+                    mb_input.seqlens["packed_input_ids"], dim=0
+                ).cuda()
                 max_seqlen = int(max(input_lens))
                 cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
                 model_output = self.module(
@@ -116,7 +120,9 @@ class PipelinableInferenceEngine:
     ):
         if constants.pipe_parallel_world_size() > 1:
             if num_micro_batches is not None:
-                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
+                num_micro_batches = max(
+                    num_micro_batches, self.pipe_runner.default_inf_mbs
+                )
             return self.pipe_runner.forward(
                 input_=input_,
                 num_micro_batches=num_micro_batches,
@@ -126,7 +132,9 @@ class PipelinableInferenceEngine:
                 num_micro_batches = 1
             outputs = []
             for mb_input in input_.split(num_micro_batches):
-                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                input_lens = torch.cat(
+                    mb_input.seqlens["packed_input_ids"], dim=0
+                ).cuda()
                 max_seqlen = int(max(input_lens))
                 cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
                 model_output = self.module(
@@ -149,7 +157,9 @@ class PipelinableInferenceEngine:
     ):
         if constants.pipe_parallel_world_size() > 1:
             if num_micro_batches is not None:
-                num_micro_batches = max(num_micro_batches, self.pipe_runner.default_inf_mbs)
+                num_micro_batches = max(
+                    num_micro_batches, self.pipe_runner.default_inf_mbs
+                )
             return self.pipe_runner.generate(
                 input_=input_,
                 num_micro_batches=num_micro_batches,
@@ -161,7 +171,9 @@ class PipelinableInferenceEngine:
                 num_micro_batches = 1
             sequences, scores, logits_mask = [], [], []
             for mb_input in input_.split(num_micro_batches):
-                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                input_lens = torch.cat(
+                    mb_input.seqlens["packed_input_ids"], dim=0
+                ).cuda()
                 max_seqlen = int(max(input_lens))
                 cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
                 res = self.module.generate(
@@ -177,7 +189,11 @@ class PipelinableInferenceEngine:
             if num_micro_batches == 1:
                 return sequences[0], scores[0], logits_mask[0]
             else:
-                return torch.cat(sequences, dim=0), torch.cat(scores, dim=0), torch.cat(logits_mask, dim=0)
+                return (
+                    torch.cat(sequences, dim=0),
+                    torch.cat(scores, dim=0),
+                    torch.cat(logits_mask, dim=0),
+                )
 
 
 @dataclasses.dataclass

--- a/realhf/impl/model/backend/inference.py
+++ b/realhf/impl/model/backend/inference.py
@@ -4,6 +4,7 @@ from typing import *
 import torch
 import torch.distributed as dist
 import transformers
+import collections
 
 import realhf.api.core.model_api as model_api
 import realhf.base.constants as constants
@@ -89,15 +90,21 @@ class PipelinableInferenceEngine:
                 num_micro_batches=num_micro_batches,
             )
         else:
-            input_lens = torch.cat(input_.seqlens["packed_input_ids"], dim=0).cuda()
-            max_seqlen = int(max(input_lens))
-            cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-            model_output = self.module(
-                packed_input_ids=input_.data["packed_input_ids"],
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            ).logits
-            _, stat = loss_fn(model_output, input_)
+            if num_micro_batches is None:
+                num_micro_batches = 1
+            stat = collections.defaultdict(int)
+            for mb_input in input_.split(num_micro_batches):
+                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                max_seqlen = int(max(input_lens))
+                cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+                model_output = self.module(
+                    packed_input_ids=mb_input.data["packed_input_ids"],
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                ).logits
+                _, _stat = loss_fn(model_output, mb_input)
+                for k, v in _stat.items():
+                    stat[k] += v
             return stat
 
     def forward(
@@ -111,15 +118,20 @@ class PipelinableInferenceEngine:
                 num_micro_batches=num_micro_batches,
             )
         else:
-            input_lens = torch.cat(input_.seqlens["packed_input_ids"], dim=0).cuda()
-            max_seqlen = int(max(input_lens))
-            cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-            model_output = self.module(
-                packed_input_ids=input_.data["packed_input_ids"],
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            ).logits
-            return model_output
+            if num_micro_batches is None:
+                num_micro_batches = 1
+            outputs = []
+            for mb_input in input_.split(num_micro_batches):
+                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                max_seqlen = int(max(input_lens))
+                cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+                model_output = self.module(
+                    packed_input_ids=mb_input.data["packed_input_ids"],
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                ).logits
+                outputs.append(model_output)
+            return torch.cat(outputs, dim=0) if num_micro_batches > 1 else outputs[0]
 
     @torch.no_grad()
     def generate(
@@ -139,17 +151,27 @@ class PipelinableInferenceEngine:
                 gconfig=gconfig,
             )
         else:
-            input_lens = torch.cat(input_.seqlens["packed_input_ids"], dim=0).cuda()
-            max_seqlen = int(max(input_lens))
-            cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-            res = self.module.generate(
-                tokenizer=tokenizer,
-                packed_input_ids=input_.data["packed_input_ids"],
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-                gconfig=gconfig,
-            )
-            return res.sequences, res.scores, res.logits_mask
+            if num_micro_batches is None:
+                num_micro_batches = 1
+            sequences, scores, logits_mask = [], [], []
+            for mb_input in input_.split(num_micro_batches):
+                input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                max_seqlen = int(max(input_lens))
+                cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+                res = self.module.generate(
+                    tokenizer=tokenizer,
+                    packed_input_ids=mb_input.data["packed_input_ids"],
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                    gconfig=gconfig,
+                )
+                sequences.append(res.sequences)
+                scores.append(res.scores)
+                logits_mask.append(res.logits_mask)
+            if num_micro_batches == 1:
+                return sequences[0], scores[0], logits_mask[0]
+            else:
+                return torch.cat(sequences, dim=0), torch.cat(scores, dim=0), torch.cat(logits_mask, dim=0)
 
 
 @dataclasses.dataclass

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -2,6 +2,7 @@ import dataclasses
 import math
 from contextlib import contextmanager
 from typing import *
+import collections
 
 import torch
 import torch.distributed as dist
@@ -731,8 +732,8 @@ class ReaLMegatronEngine:
         with megatron_ctx():
             self.engine.zero_grad()
             if constants.pipe_parallel_world_size() > 1:
-                if num_micro_batches is None:
-                    num_micro_batches = self.pipe_runner.default_train_mbs
+                if num_micro_batches is not None:
+                    num_micro_batches = max(num_micro_batches, self.pipe_runner.default_train_mbs)
                 instr_set = PipeTrainInstrSetForMegatron(self.engine, num_micro_batches)
                 return self.pipe_runner.train_batch(
                     instr_set=instr_set,

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -1,8 +1,8 @@
+import collections
 import dataclasses
 import math
 from contextlib import contextmanager
 from typing import *
-import collections
 
 import torch
 import torch.distributed as dist
@@ -733,7 +733,9 @@ class ReaLMegatronEngine:
             self.engine.zero_grad()
             if constants.pipe_parallel_world_size() > 1:
                 if num_micro_batches is not None:
-                    num_micro_batches = max(num_micro_batches, self.pipe_runner.default_train_mbs)
+                    num_micro_batches = max(
+                        num_micro_batches, self.pipe_runner.default_train_mbs
+                    )
                 instr_set = PipeTrainInstrSetForMegatron(self.engine, num_micro_batches)
                 return self.pipe_runner.train_batch(
                     instr_set=instr_set,
@@ -751,9 +753,13 @@ class ReaLMegatronEngine:
                 for i, mb_input in enumerate(input_.split(num_micro_batches)):
                     if i == num_micro_batches - 1:
                         no_sync_ctx.__exit__(None, None, None)
-                    input_lens = torch.cat(mb_input.seqlens["packed_input_ids"], dim=0).cuda()
+                    input_lens = torch.cat(
+                        mb_input.seqlens["packed_input_ids"], dim=0
+                    ).cuda()
                     max_seqlen = int(max(input_lens))
-                    cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+                    cu_seqlens = torch.nn.functional.pad(
+                        input_lens.cumsum(0), (1, 0)
+                    ).int()
                     model_output = self.engine.ddp(
                         packed_input_ids=mb_input.data["packed_input_ids"],
                         cu_seqlens=cu_seqlens,

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -733,9 +733,17 @@ class ReaLMegatronEngine:
             self.engine.zero_grad()
             if constants.pipe_parallel_world_size() > 1:
                 if num_micro_batches is not None:
+                    if num_micro_batches > self.pipe_runner.default_train_mbs:
+                        logger.warning(
+                            "When training with pipeline parallel, num micro batches should be "
+                            "larger than 2 x num_pipeline_stages to avoid idle time. "
+                            f"Setting num_micro_batches to {self.pipe_runner.default_train_mbs}"
+                        )
                     num_micro_batches = max(
                         num_micro_batches, self.pipe_runner.default_train_mbs
                     )
+                else:
+                    num_micro_batches = self.pipe_runner.default_train_mbs
                 instr_set = PipeTrainInstrSetForMegatron(self.engine, num_micro_batches)
                 return self.pipe_runner.train_batch(
                     instr_set=instr_set,
@@ -789,7 +797,7 @@ class ReaLMegatronEngine:
                         f"Grad Norm: {grad_norm}. "
                         f"Current loss scale: {self.engine.optim.get_loss_scale()}. "
                     )
-                return stat
+                return _stat
 
     @torch.no_grad()
     def eval_batch(

--- a/realhf/impl/model/comm/param_realloc.py
+++ b/realhf/impl/model/comm/param_realloc.py
@@ -332,9 +332,7 @@ def _derive_reparallelize_comm_plan(
     assert src_mp_size % dst_mp_size == 0 or dst_mp_size % src_mp_size == 0
     for k, v in dataclasses.asdict(to_model_config).items():
         if k not in [
-            "is_critic",
-            "sequence_parallel",
-            "gradient_accumulation_fusion",
+            "is_critic"
         ] and v != getattr(from_model_config, k):
             raise ValueError(
                 f"Can't load a checkpoint with different config (key `{k}`, "

--- a/realhf/impl/model/comm/param_realloc.py
+++ b/realhf/impl/model/comm/param_realloc.py
@@ -331,9 +331,7 @@ def _derive_reparallelize_comm_plan(
     dst_mp_size = to_topo.get_dim("model")
     assert src_mp_size % dst_mp_size == 0 or dst_mp_size % src_mp_size == 0
     for k, v in dataclasses.asdict(to_model_config).items():
-        if k not in [
-            "is_critic"
-        ] and v != getattr(from_model_config, k):
+        if k not in ["is_critic"] and v != getattr(from_model_config, k):
             raise ValueError(
                 f"Can't load a checkpoint with different config (key `{k}`, "
                 f"value in checkpoint is `{v}`, current value is `{getattr(from_model_config, k)}`)."

--- a/realhf/impl/model/interface/dpo_interface.py
+++ b/realhf/impl/model/interface/dpo_interface.py
@@ -101,12 +101,12 @@ class DPOInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
 
-        logits = module.forward(input_=input_)
+        logits = module.forward(input_=input_, num_micro_batches=n_mbs)
         if logits is None:
             return None
 
@@ -159,7 +159,7 @@ class DPOInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
         module = model.module
 
         # Determining whether to disable dropout is a bit tricky.
@@ -170,6 +170,7 @@ class DPOInterface(model_api.ModelInterface):
             input_=input_,
             version_steps=model.version.global_step,
             loss_fn=functools.partial(_dpo_loss_from_model_outputs, beta=self.beta),
+            num_micro_batches=n_mbs,
         )
 
         model.inc_version()

--- a/realhf/impl/model/interface/dpo_interface.py
+++ b/realhf/impl/model/interface/dpo_interface.py
@@ -101,7 +101,10 @@ class DPOInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
@@ -159,7 +162,9 @@ class DPOInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
+    def train_step(
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
+    ) -> Dict:
         module = model.module
 
         # Determining whether to disable dropout is a bit tricky.

--- a/realhf/impl/model/interface/gen_interface.py
+++ b/realhf/impl/model/interface/gen_interface.py
@@ -15,7 +15,7 @@ class GenerationInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
     ) -> SequenceSample:
         module = model.module
 
@@ -33,6 +33,7 @@ class GenerationInterface(model_api.ModelInterface):
             input_=x,
             tokenizer=model.tokenizer,
             gconfig=self.generation_config,
+            num_micro_batches=n_mbs,
         )
         if res is None:
             return None

--- a/realhf/impl/model/interface/gen_interface.py
+++ b/realhf/impl/model/interface/gen_interface.py
@@ -15,7 +15,10 @@ class GenerationInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         module = model.module
 

--- a/realhf/impl/model/interface/ppo_interface.py
+++ b/realhf/impl/model/interface/ppo_interface.py
@@ -177,7 +177,7 @@ class PPOActorInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
     ) -> SequenceSample:
         module = model.module
 
@@ -195,6 +195,7 @@ class PPOActorInterface(model_api.ModelInterface):
             input_=x,
             tokenizer=model.tokenizer,
             gconfig=self.generation_config,
+            num_micro_batches=n_mbs,
         )
         if res is None:
             return None
@@ -250,12 +251,12 @@ class PPOActorInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
 
-        logits = module.forward(input_=input_)
+        logits = module.forward(input_=input_, num_micro_batches=n_mbs)
         if logits is None:
             return None
 
@@ -277,7 +278,7 @@ class PPOActorInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
         module = model.module
         # We call module.eval() because dropout causes the computation of incorrect of log probs.
         module.eval()
@@ -419,6 +420,7 @@ class PPOActorInterface(model_api.ModelInterface):
             stats = module.train_batch(
                 input_=data,
                 version_steps=model.version.global_step,
+                num_micro_batches=n_mbs,
                 loss_fn=functools.partial(
                     _ppo_actor_loss_from_model_outputs,
                     kl_adapter=self.kl_adapter,
@@ -574,12 +576,12 @@ class PPOCriticInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
 
-        scores = module.forward(input_=input_)
+        scores = module.forward(input_=input_, num_micro_batches=n_mbs)
         if scores is None:
             return None
         scores = scores.squeeze(-1)
@@ -590,7 +592,7 @@ class PPOCriticInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
         module = model.module
         tokenizer = model.tokenizer
         # We call module.eval() because dropout causes the computation of incorrect of log probs.
@@ -703,6 +705,7 @@ class PPOCriticInterface(model_api.ModelInterface):
                     kl_adapter=self.kl_adapter,
                     rms=None if not self.value_norm else self.rms,
                 ),
+                num_micro_batches=n_mbs,
             )
 
             if stats:

--- a/realhf/impl/model/interface/ppo_interface.py
+++ b/realhf/impl/model/interface/ppo_interface.py
@@ -177,7 +177,10 @@ class PPOActorInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def generate(
-        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         module = model.module
 
@@ -251,7 +254,10 @@ class PPOActorInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
@@ -278,7 +284,9 @@ class PPOActorInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
+    def train_step(
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
+    ) -> Dict:
         module = model.module
         # We call module.eval() because dropout causes the computation of incorrect of log probs.
         module.eval()
@@ -576,7 +584,10 @@ class PPOCriticInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample, n_mbs=None,
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs=None,
     ) -> SequenceSample:
         module = model.module
         module.eval()
@@ -592,7 +603,9 @@ class PPOCriticInterface(model_api.ModelInterface):
         )
         return res
 
-    def train_step(self, model: model_api.Model, input_: SequenceSample, n_mbs=None) -> Dict:
+    def train_step(
+        self, model: model_api.Model, input_: SequenceSample, n_mbs=None
+    ) -> Dict:
         module = model.module
         tokenizer = model.tokenizer
         # We call module.eval() because dropout causes the computation of incorrect of log probs.

--- a/realhf/impl/model/interface/rw_interface.py
+++ b/realhf/impl/model/interface/rw_interface.py
@@ -111,13 +111,13 @@ class PairedRewardInterface(model_api.ModelInterface):
     train_total_correct_predictions: int = 0
 
     @torch.no_grad()
-    def inference(self, model: model_api.Model, data: SequenceSample) -> SequenceSample:
+    def inference(self, model: model_api.Model, data: SequenceSample, n_mbs=None) -> SequenceSample:
 
         module = model.module
 
         module.eval()
 
-        r = module.forward(input_=data)
+        r = module.forward(input_=data, num_micro_batches=n_mbs)
         if r is None:
             return
         scores = r.float()
@@ -154,7 +154,7 @@ class PairedRewardInterface(model_api.ModelInterface):
         return res
 
     def train_step(
-        self, model: model_api.Model, data: SequenceSample
+        self, model: model_api.Model, data: SequenceSample, n_mbs=None
     ) -> SequenceSample:
         module = model.module
         module.train()
@@ -163,6 +163,7 @@ class PairedRewardInterface(model_api.ModelInterface):
             input_=data,
             loss_fn=_paired_rw_loss_from_model_outputs,
             version_steps=model.version.global_step,
+            num_micro_batches=n_mbs,
         )
 
         res = {}

--- a/realhf/impl/model/interface/rw_interface.py
+++ b/realhf/impl/model/interface/rw_interface.py
@@ -111,7 +111,9 @@ class PairedRewardInterface(model_api.ModelInterface):
     train_total_correct_predictions: int = 0
 
     @torch.no_grad()
-    def inference(self, model: model_api.Model, data: SequenceSample, n_mbs=None) -> SequenceSample:
+    def inference(
+        self, model: model_api.Model, data: SequenceSample, n_mbs=None
+    ) -> SequenceSample:
 
         module = model.module
 

--- a/realhf/impl/model/interface/sft_interface.py
+++ b/realhf/impl/model/interface/sft_interface.py
@@ -85,7 +85,7 @@ def compute_packed_sft_loss(
 
 class SFTInterface(model_api.ModelInterface):
 
-    def train_step(self, model: model_api.Model, x: SequenceSample) -> Dict:
+    def train_step(self, model: model_api.Model, x: SequenceSample, n_mbs=None) -> Dict:
         module = model.module
 
         module.train()
@@ -93,7 +93,7 @@ class SFTInterface(model_api.ModelInterface):
         stat = module.train_batch(
             input_=x,
             loss_fn=compute_packed_sft_loss,
-            num_micro_batches=constants.pipe_parallel_world_size() * 2,
+            num_micro_batches=n_mbs,
             version_steps=model.version.global_step,
         )
 

--- a/realhf/impl/model/modules/attn.py
+++ b/realhf/impl/model/modules/attn.py
@@ -4,8 +4,8 @@ import torch
 import torch.nn as nn
 import torch.utils.checkpoint
 
-import realhf.base.logging as logging
 import realhf.base.constants as constants
+import realhf.base.logging as logging
 from realhf.impl.model.parallelism.model_parallel.modules import RowParallelLinear
 from realhf.impl.model.utils.functional import (
     apply_rotary_varlen,

--- a/realhf/impl/model/modules/mlp.py
+++ b/realhf/impl/model/modules/mlp.py
@@ -25,6 +25,7 @@ def get_activation_fn(activation_function: str) -> Callable:
 
 
 SPLIT_KV_HEADS_WARNED = False
+SEQUENCE_PARALLEL_WARNED = False
 
 
 class LayerNormQKVLinear(nn.Module):

--- a/realhf/impl/model/modules/mlp.py
+++ b/realhf/impl/model/modules/mlp.py
@@ -224,7 +224,6 @@ class LayerNormQKVLinear(nn.Module):
 
 
 class LayerNormMLP(nn.Module):
-    SEQUENCE_PARALLEL_WARNED = False
 
     def __init__(
         self,

--- a/realhf/impl/model/modules/moe/experts.py
+++ b/realhf/impl/model/modules/moe/experts.py
@@ -25,6 +25,7 @@ except ImportError:
 
 class SequentialMLP(torch.nn.Module):
     """An implementation of the Experts layer using a sequence of MLP layers.
+
     This class executes each expert sequentially.
     """
 
@@ -73,9 +74,8 @@ class SequentialMLP(torch.nn.Module):
 
 
 class ExpertParam(torch.nn.Module):
-    """A dummy class that maps weight tensors in GroupedMLP to pytorch parameters
-    for compatibility of weight saving/loading.
-    """
+    """A dummy class that maps weight tensors in GroupedMLP to pytorch
+    parameters for compatibility of weight saving/loading."""
 
     def __init__(
         self,

--- a/realhf/impl/model/modules/moe/router.py
+++ b/realhf/impl/model/modules/moe/router.py
@@ -189,7 +189,7 @@ class TopKRouter(torch.nn.Module):
         return input
 
     def routing(self, logits: torch.Tensor):
-        """Top-k routing function
+        """Top-k routing function.
 
         Args:
             logits (torch.Tensor): Logits tensor after gating.
@@ -228,8 +228,7 @@ class TopKRouter(torch.nn.Module):
         return scores, indices
 
     def forward(self, input: torch.Tensor):
-        """
-        Forward pass of the router.
+        """Forward pass of the router.
 
         Args:
             input (torch.Tensor): Input tensor.

--- a/realhf/impl/model/modules/moe/token_dispatcher.py
+++ b/realhf/impl/model/modules/moe/token_dispatcher.py
@@ -15,9 +15,7 @@ from realhf.impl.model.utils.moe import custom_histc, permute, unpermute
 
 
 class MoETokenDispatcher:
-    """
-    AlltoAll Based Token dispatcher.
-    """
+    """AlltoAll Based Token dispatcher."""
 
     def __init__(
         self,
@@ -25,8 +23,8 @@ class MoETokenDispatcher:
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        """
-        Initialize the AlltoAll token dispatcher. Currently does not support expert parallel.
+        """Initialize the AlltoAll token dispatcher. Currently does not support
+        expert parallel.
 
         Args:
             num_local_experts (int): Number of local experts on the current device.
@@ -60,10 +58,11 @@ class MoETokenDispatcher:
         self.num_out_tokens = torch.tensor(0, dtype=torch.long, device=self.device)
 
     def preprocess(self, indices: torch.Tensor) -> torch.Tensor:
-        """
-        Preprocess token indices for AlltoAll communication and token permutation. This method computes the number of tokens assigned to each expert based on the input indices.
-        It also initializes the necessary data structures for AlltoAll communication, such as input
-        and output splits, and the mapping between global tokens and local experts.
+        """Preprocess token indices for AlltoAll communication and token
+        permutation. This method computes the number of tokens assigned to each
+        expert based on the input indices. It also initializes the necessary
+        data structures for AlltoAll communication, such as input and output
+        splits, and the mapping between global tokens and local experts.
 
         Args:
             indices (torch.Tensor): Tensor of indices mapping tokens to experts.
@@ -94,8 +93,7 @@ class MoETokenDispatcher:
         probs: torch.Tensor,
         indices: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Dispatch tokens to local experts using AlltoAll communication.
+        """Dispatch tokens to local experts using AlltoAll communication.
 
         Args:
             hidden_states (torch.Tensor): Input token embeddings.
@@ -135,8 +133,7 @@ class MoETokenDispatcher:
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        """
-        Reverse the token permutation to restore the original order.
+        """Reverse the token permutation to restore the original order.
 
         Args:
             hidden_states (torch.Tensor): Output from local experts.

--- a/realhf/impl/model/nn/real_llm_api.py
+++ b/realhf/impl/model/nn/real_llm_api.py
@@ -265,7 +265,7 @@ class ReaLModel(nn.Module):
                 config.vocab_size,
                 bias=False,
                 async_tensor_model_parallel_allreduce=not constants.sequence_parallel(),
-                gradient_accumulation_fusion=config.gradient_accumulation_fusion,
+                gradient_accumulation_fusion=constants.gradient_accumulation_fusion(),
                 device=device,
                 dtype=dtype,
             )

--- a/realhf/impl/model/nn/real_llm_base.py
+++ b/realhf/impl/model/nn/real_llm_base.py
@@ -135,8 +135,6 @@ class ReaLModelBlock(nn.Module):
             rotary_interleaved=config.rotary_interleaved,
             rotary_scaling=config.rotary_scaling,
             rotary_scaling_type=config.rotary_scaling_type,
-            model_parallel=constants.model_parallel_world_size() > 1,
-            gradient_accumulation_fusion=config.gradient_accumulation_fusion,
             dtype=dtype,
             device=device,
         )
@@ -148,8 +146,6 @@ class ReaLModelBlock(nn.Module):
                 do_layernorm_before=config.do_layernorm_before,
                 activation_function=config.activation_function,
                 layer_norm_epsilon=config.layer_norm_epsilon,
-                model_parallel=constants.model_parallel_world_size() > 1,
-                gradient_accumulation_fusion=config.gradient_accumulation_fusion,
                 dtype=dtype,
                 device=device,
             )
@@ -160,8 +156,6 @@ class ReaLModelBlock(nn.Module):
                 activation_function=config.activation_function,
                 layer_norm_epsilon=config.layer_norm_epsilon,
                 layer_norm_type=config.layer_norm_type,
-                model_parallel=constants.model_parallel_world_size() > 1,
-                gradient_accumulation_fusion=config.gradient_accumulation_fusion,
                 dtype=dtype,
                 device=device,
             )

--- a/realhf/impl/model/utils/moe.py
+++ b/realhf/impl/model/utils/moe.py
@@ -67,7 +67,7 @@ def z_loss_func(logits, z_loss_coeff):
 
 
 def sinkhorn(cost: torch.Tensor, tol: float = 0.0001):
-    """Sinkhorn based MoE routing function"""
+    """Sinkhorn based MoE routing function."""
     cost = torch.exp(cost)
     d0 = torch.ones(cost.size(0), device=cost.device, dtype=cost.dtype)
     d1 = torch.ones(cost.size(1), device=cost.device, dtype=cost.dtype)
@@ -86,8 +86,7 @@ def sinkhorn(cost: torch.Tensor, tol: float = 0.0001):
 def get_capacity(
     num_tokens: int, num_experts: int, capacity_factor: float, min_capacity=None
 ):
-    """
-    Calculate the capacity of each expert.
+    """Calculate the capacity of each expert.
 
     Args:
         num_tokens (int): num of the input tokens.
@@ -129,7 +128,8 @@ class MoEAuxLossAutoScaler(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, output: torch.Tensor, aux_loss: torch.Tensor):
-        """Preserve the aux_loss by storing it in the context to avoid garbage collection.
+        """Preserve the aux_loss by storing it in the context to avoid garbage
+        collection.
 
         Args:
             output (torch.Tensor): The output tensor.
@@ -158,7 +158,7 @@ class MoEAuxLossAutoScaler(torch.autograd.Function):
 
     @staticmethod
     def set_loss_scale(scale: torch.Tensor):
-        """set the scale of the aux loss.
+        """Set the scale of the aux loss.
 
         Args:
             scale (torch.Tensor): The scale value to set. Please ensure that the scale passed in matches the scale of the main_loss.
@@ -202,7 +202,8 @@ def unpermute(
     padded_mode: bool = False,
     restore_shape: torch.Size = None,
 ):
-    """Unpermute a tensor of permuted tokens based on sorted indices, and optionally merge the tokens with their corresponding probabilities.
+    """Unpermute a tensor of permuted tokens based on sorted indices, and
+    optionally merge the tokens with their corresponding probabilities.
 
     Args:
         permuted_tokens (torch.Tensor): The tensor of permuted tokens to be unpermuted.
@@ -265,8 +266,8 @@ def unpermute_with_padded_tokens(
     probs: torch.Tensor,
     restore_shape: torch.Size,
 ) -> torch.Tensor:
-    """
-    Unpermutes a padded permuted tokens based on sorted indices and merges the tokens with their corresponding probabilities.
+    """Unpermutes a padded permuted tokens based on sorted indices and merges
+    the tokens with their corresponding probabilities.
 
     This function takes a tensor of permuted tokens and reorders them according to the provided indices. It also combines the tokens with their associated probabilities.
 
@@ -278,7 +279,6 @@ def unpermute_with_padded_tokens(
 
     Returns:
         torch.Tensor: A tensor of unpermuted tokens, merged with their probabilities.
-
     """
     # Ensure permuted_tokens is 2D
     assert permuted_tokens.dim() == 2, f"Got {permuted_tokens.dim()}D."
@@ -396,6 +396,7 @@ def update_aux_losses_tracker(
     name: str, loss: torch.Tensor, layer_number: int, num_layers: int
 ):
     """Save the auxiliary loss for logging.
+
     Args:
         name (str): The name of the loss.
         loss (torch.Tensor): The loss tensor.

--- a/realhf/impl/model/utils/random.py
+++ b/realhf/impl/model/utils/random.py
@@ -313,8 +313,9 @@ def _initialize_affine_weight_cpu(
 ):
     """Initialize affine weight for model parallel.
 
-    Build the master weight on all processes and scatter
-    the relevant chunk."""
+    Build the master weight on all processes and scatter the relevant
+    chunk.
+    """
 
     set_tensor_model_parallel_attributes(
         tensor=weight, is_parallel=True, dim=partition_dim, stride=stride

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -666,11 +666,11 @@ class ModelWorker(worker_base.Worker):
             data.remap_keys_(rpc.input_key_remap)
 
         if request.handle_name == "inference":
-            res = self._interface.inference(self._model, data)  # -> SequenceSample
+            res = self._interface.inference(self._model, data, n_mbs=rpc.n_mbs)  # -> SequenceSample
         elif request.handle_name == "train_step":
-            res = self._interface.train_step(self._model, data)  # -> Dict
+            res = self._interface.train_step(self._model, data, n_mbs=rpc.n_mbs)  # -> Dict
         elif request.handle_name == "generate":
-            res = self._interface.generate(self._model, data)  # -> SequenceSample
+            res = self._interface.generate(self._model, data, n_mbs=rpc.n_mbs)  # -> SequenceSample
         else:
             raise NotImplementedError(f"Unknown MFC type: {request.handle_name}.")
 

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -666,11 +666,17 @@ class ModelWorker(worker_base.Worker):
             data.remap_keys_(rpc.input_key_remap)
 
         if request.handle_name == "inference":
-            res = self._interface.inference(self._model, data, n_mbs=rpc.n_mbs)  # -> SequenceSample
+            res = self._interface.inference(
+                self._model, data, n_mbs=rpc.n_mbs
+            )  # -> SequenceSample
         elif request.handle_name == "train_step":
-            res = self._interface.train_step(self._model, data, n_mbs=rpc.n_mbs)  # -> Dict
+            res = self._interface.train_step(
+                self._model, data, n_mbs=rpc.n_mbs
+            )  # -> Dict
         elif request.handle_name == "generate":
-            res = self._interface.generate(self._model, data, n_mbs=rpc.n_mbs)  # -> SequenceSample
+            res = self._interface.generate(
+                self._model, data, n_mbs=rpc.n_mbs
+            )  # -> SequenceSample
         else:
             raise NotImplementedError(f"Unknown MFC type: {request.handle_name}.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ redis
 scipy
 seaborn
 setuptools>=61.0
-torch
+torch==2.3.1
 tqdm
 transformers==4.42.3
 networkx==3.3


### PR DESCRIPTION
Changes:

+ Fix the `gradient_accumulation_fusion` implementation adopted from Megatron.

+ Add an additional argument `n_mbs` in all model interfaces.

+ Implement micro-batch splitting in the inference/Megatron/DeepSpeed backends.