### PR TITLE
[WIP] Custom CUDAGraph to accelerate PPO without memory waste

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export MAX_JOBS=8
 
 # GPU dependencies, not required on the launcher node.
 pip install git+https://github.com/NVIDIA/TransformerEngine.git@v1.4 --no-deps --no-build-isolation
-pip install flash_attn==2.4.2 --no-build-isolation
+pip install flash_attn==2.6.3 --no-build-isolation # compatible with torch 2.3.1
 pip install grouped_gemm  # For MoE
 
 REAL_CUDA=1 pip install -e . --no-build-isolation

--- a/csrc/custom_cudagraph/custom_cudagraph.cpp
+++ b/csrc/custom_cudagraph/custom_cudagraph.cpp
@@ -1,0 +1,385 @@
+// Copied and modified from
+// https://github.com/pytorch/pytorch/blob/v2.3.1/aten/src/ATen/cuda/CUDAGraph.cpp This
+// implementation enables efficient graph recapture, which is used to save memory without degrading
+// performance. When a graph is used periodically, its memory could not be released when the graph
+// is unused. Then to save memory, this graph should be destroyed and recaptured. However in
+// original pytorch implementation, recapturing the graph is expensive. This implementation uses
+// `cudaGraphExecUpdate` to recapture the graph efficiently. NOTE:
+// 1. This extension could only be compiled under torch version 2.3.1.
+//    Otherwise compile may fail due to incompatible APIs in pytorch source code.
+// 2. Compared to original pytorch CUDAGraph implementation, some features such as memory pool
+// sharing is disabled
+//    in this extension.
+//    It is also unsafe to mix the usage of this and the original pytorch one.
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/Functions.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAFunctions.h>
+
+#include <chrono>
+#include <thread>
+
+#include "custom_cudagraph.h"
+
+namespace at::cuda {
+
+constexpr int kSynchronizeBusyWaitMillis = 10;
+
+MempoolId_t graph_pool_handle() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  // uuid count starts at 1. 0 is reserved to mean "wasn't set by graph_pool_handle".
+  static std::atomic<CaptureId_t> uid{1};
+  // Sets just the second value, to distinguish it from MempoolId_ts created from
+  // cudaStreamGetCaptureInfo id_s in capture_begin.
+  return {0, uid++};
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+  return {0, 0};
+#endif
+}
+
+// Get the expected id of a capture sequence so that we can call beginAllocateStreamToPool
+// before starting a graph capture
+CaptureId_t capture_sequence_id() {
+  // id starts at 1:
+  // Ensures uuid count starts at 1. 0 is reserved to mean "not set by cudaStreamGetCaptureInfo".
+  // (But how do we know GetCaptureInfo never sets id_ to 0? Because that's the current behavior,
+  // and I asked cuda devs to keep it that way, and they agreed.)
+  static std::atomic<CaptureId_t> uuid{1};
+  return uuid++;
+}
+
+/**
+ * Note [CUDA Graph Wrapper Class]
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Q: Why do we need graph capture and launch bindings in Pytorch?
+ *    Why can't they live in a user extension, for example?
+ *
+ * A1: Convenience.
+ * A2: To ensure valid numerics on replay, some native CUDA ops (like RNG ops with
+ *     CPU statefulness) need cooperation from the capture and replay bindings
+ *     (see Note [CUDA Graph-safe RNG states] in CUDAGeneratorImpl.h).
+ *
+ *     We can't expect users to know about this cooperation.  If users write capture
+ *     bindings naively in an extension, they likely won't interact with the native
+ *     ops properly.  Their graphs would yield invalid numerics on replay.
+ */
+
+/**
+ * Note [Interaction with CUDA graph capture] in CUDACachingAllocator.cpp
+ * describes memory management for captures.
+ */
+
+std::atomic<int> CustomizedCUDAGraph::pending_event_queries = 0;
+
+// Track any outstanding event queries that could happen e.g., in a NCCL watchdog so that they
+// can be resolved before the capture begins. Note that event queries are not allowed during a
+// graph capture in the default capture mode.
+void CustomizedCUDAGraph::inc_pending_event_queries() { pending_event_queries++; }
+
+void CustomizedCUDAGraph::dec_pending_event_queries() {
+  TORCH_INTERNAL_ASSERT(
+      pending_event_queries > 0,
+      "Attempted to decrement the number of outstanding events to be queried, but it was <= 0.");
+  pending_event_queries--;
+}
+
+int CustomizedCUDAGraph::num_pending_event_queries() { return pending_event_queries; }
+
+CustomizedCUDAGraph::CustomizedCUDAGraph()
+    // CUDAStreams may not be default-constructed.
+    : capture_stream_(at::cuda::getCurrentCUDAStream()) {
+#if (defined(USE_ROCM) && ROCM_VERSION < 50300)
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3");
+#endif
+}
+
+void CustomizedCUDAGraph::capture_begin(
+    // MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode
+) {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  MempoolId_t pool = {0, 0};
+  cudaStreamCaptureMode capture_mode = cudaStreamCaptureModeGlobal;
+  //   TORCH_CHECK(!has_graph_exec_,
+  //               "This CustomizedCUDAGraph instance already owns a captured graph. "
+  //               "To capture a new graph, create a new instance.");
+
+  // For now, a CUDAGraph instance only accommodates the default generator on the device that's
+  // current when capture begins. If any op in the captured region uses a non-default generator,
+  // or a generator on another device, the offending generator will throw an error.
+  // These restrictions simplify CUDAGraph, but could be relaxed in the future:
+  // in principle, the underlying Cuda calls do permit cross-device ops to be captured.
+  auto *gen = get_generator_or_default<CUDAGeneratorImpl>(c10::nullopt,
+                                                          cuda::detail::getDefaultCUDAGenerator());
+
+  auto options = TensorOptions().device(at::kCUDA).dtype(at::kLong);
+  seed_extragraph_ = at::empty({1}, options);
+  offset_extragraph_ = at::empty({1}, options);
+
+  seed_extragraph_.fill_(int64_t(gen->current_seed()));
+  gen->capture_prologue(seed_extragraph_.data_ptr<int64_t>(),
+                        offset_extragraph_.mutable_data_ptr<int64_t>());
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  TORCH_CHECK(stream != at::cuda::getDefaultCUDAStream(),
+              "CUDA graphs must be captured on a non-default stream. "
+              "(However, after capture, it's ok to replay them on the "
+              "default stream.)");
+
+  capture_stream_ = stream;
+  capture_gen_ = gen;
+  capture_dev_ = c10::cuda::current_device();
+
+  id_ = capture_sequence_id();
+
+  if (pool.first != 0 || pool.second != 0) {
+    // Either value being nonzero means the user supplied a pool to share.
+    // But only one should be nonzero.
+    // If pool was created by another graph's capture_begin, first should be nonzero.
+    // If pool was created by graph_pool_handle, second should be nonzero.
+    TORCH_INTERNAL_ASSERT(!(pool.first && pool.second));
+    mempool_id_ = pool;
+  } else {
+    // User did not ask us to share a mempool. Use our own id_ as our mempool_id_.
+    // Sets just the first value, to distinguish it from MempoolId_ts created by
+    // graph_pool_handle().
+    mempool_id_ = {id_, 0};
+  }
+
+  // Addendum: beginAllocateStreamToPool is now called before cudaStreamBeginCapture to prevent an
+  // autograd thread's free() call triggering an invalid cudaEventRecord in the caching allocator
+  // due to the capture status being updated _after_ a capture had already started.
+  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+      capture_dev_, mempool_id_, [this](cudaStream_t stream) {
+        cudaStreamCaptureStatus status;
+        CaptureId_t stream_capture_id;
+        AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &stream_capture_id));
+        return status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive
+               && stream_capture_id == capture_id_;
+      });
+
+  // At this point, any NCCL watchdogs should be aware that we are in capture mode
+  // and therefore should not enqueue any additional work that could be event-queried.
+  // We still must wait on any existing work that has not been cleaned up.
+  while (num_pending_event_queries()) {
+    TORCH_WARN_ONCE("Waiting for pending NCCL work to finish before starting graph capture.");
+    std::this_thread::sleep_for(std::chrono::milliseconds(kSynchronizeBusyWaitMillis));
+  }
+
+  // cudaStreamCaptureModeGlobal is the most conservative option to
+  // prevent potentially unsafe CUDA API calls during capture.  See
+  // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
+  AT_CUDA_CHECK(cudaStreamBeginCapture(capture_stream_, capture_mode));
+
+  cudaStreamCaptureStatus status;
+  AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &capture_id_));
+  TORCH_INTERNAL_ASSERT(status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive);
+
+  TORCH_INTERNAL_ASSERT(id_ > 0);
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+#endif
+}
+
+void CustomizedCUDAGraph::capture_end() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  TORCH_CHECK(stream == capture_stream_, "Capture must end on the same stream it began on.");
+
+  AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));
+
+  c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
+
+  TORCH_CHECK(graph_ != NULL, "Invalid capture.");
+
+  auto *gen = get_generator_or_default<CUDAGeneratorImpl>(c10::nullopt,
+                                                          cuda::detail::getDefaultCUDAGenerator());
+  TORCH_CHECK(gen == capture_gen_, "Default CUDA RNG generator on current device at capture end "
+                                   "is different from default generator on current device "
+                                   "when capture began");
+  wholegraph_increment_ = gen->capture_epilogue();
+
+  size_t numCUDAGraphNodes = 0;
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph_, NULL, &numCUDAGraphNodes));
+  if (numCUDAGraphNodes == 0) {
+    TORCH_WARN("The CUDA Graph is empty. This usually means that the graph was ",
+               "attempted to be captured on wrong device or stream.");
+  }
+
+  has_graph_ = true;
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+#endif
+}
+
+void CustomizedCUDAGraph::instantiate() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  // In typical graph usage some tensors (e.g. the tensors used for graph IO) are not freed
+  // between replays.
+  // If Pytorch compiles and runs with a CUDA 11.4+ toolkit, there's a chance the allocator backend
+  // is cudaMallocAsync.
+  // cudaMallocAsync is generally graph-safe, but if some tensors are not freed between replays,
+  // the graph's internal bookkeeping requires that we instantiate with
+  // cudaGraphInstantiateFlagAutoFreeOnLaunch. See
+  // cudaGraphLaunch
+  // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1g1accfe1da0c605a577c22d9751a09597
+  // cudaGraphInstantiateWithFlags
+  // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1ga2c652a24ba93e52b99a47bec0888233
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11040)
+  int version;
+  AT_CUDA_CHECK(cudaDriverGetVersion(&version));
+  if (version < 11040) {
+#endif
+    // Trailing NULL, NULL, 0 arguments were recommended by Cuda driver people,
+    // who prefer not to report error message through these arguments moving forward
+    // (they prefer return value, or errors on api calls internal to the capture)
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    AT_CUDA_CHECK(cudaGraphInstantiate(&graph_exec_, graph_, 0));
+#else
+  AT_CUDA_CHECK(cudaGraphInstantiate(&graph_exec_, graph_, NULL, NULL, 0));
+#endif
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11040)
+  } else {
+    AT_CUDA_CHECK(cudaGraphInstantiateWithFlags(&graph_exec_, graph_,
+                                                cudaGraphInstantiateFlagAutoFreeOnLaunch));
+  }
+#endif
+
+  has_graph_exec_ = true;
+
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+#endif
+}
+
+void CustomizedCUDAGraph::destroy() {
+// destroy CUDAGraph instance but not CUDAGraphExec
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  TORCH_CHECK(has_graph_,
+              "Called CustomizedCUDAGraph::destroy without a preceding successful capture."
+              "Nothing to destroy.");
+
+  c10::cuda::CUDACachingAllocator::releasePool(capture_dev_, mempool_id_);
+  C10_CUDA_CHECK_WARN(cudaGraphDestroy(graph_));
+  has_graph_ = false;
+#else
+  TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");
+#endif
+}
+
+void CustomizedCUDAGraph::update() {
+// Update CUDAGraphExec with newly captured CUDAGraph, to update memory pointers but retain graph
+// topology.
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  TORCH_CHECK(has_graph_, "Called CustomizedCUDAGraph::update without a newly captured CUDAGraph.");
+  TORCH_CHECK(has_graph_exec_,
+              "Called CustomizedCUDAGraph::update without a instantiated CUDAGraphExec.");
+  cudaGraphExecUpdateResultInfo updateResultInfo;
+  cudaGraphExecUpdate(graph_exec_, graph_, &updateResultInfo);
+
+  // if update failed, just re-instantiate the graph
+  if (updateResultInfo.result != cudaGraphExecUpdateSuccess) {
+    TORCH_WARN("CUDA Graph update failed, re-instantiating the graph.");
+    C10_CUDA_CHECK_WARN(cudaGraphExecDestroy(graph_exec_));
+    has_graph_exec_ = false;
+    CustomizedCUDAGraph::instantiate();
+  }
+#else
+  TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");
+#endif
+}
+
+void CustomizedCUDAGraph::replay() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  TORCH_CHECK(has_graph_exec_, "Called CUDAGraph::replay without a preceding successful capture.");
+
+  c10::OptionalDeviceGuard device_guard{capture_stream_.device()};
+
+  // Just like any RNG consumer kernel!
+  auto *gen = get_generator_or_default<CUDAGeneratorImpl>(c10::nullopt,
+                                                          cuda::detail::getDefaultCUDAGenerator());
+  PhiloxCudaState rng_engine_inputs;
+  {
+    std::lock_guard<std::mutex> lock(gen->mutex_);
+    rng_engine_inputs = gen->philox_cuda_state(wholegraph_increment_);
+  }
+  seed_extragraph_.fill_(int64_t(gen->current_seed()));
+  offset_extragraph_.fill_(int64_t(rng_engine_inputs.offset_.val));
+
+  // graph_exec_ may be replayed in any stream.
+  AT_CUDA_CHECK(cudaGraphLaunch(graph_exec_, at::cuda::getCurrentCUDAStream()));
+
+  int version;
+  AT_CUDA_CHECK(cudaDriverGetVersion(&version));
+  if (version < 11040) {
+    // Workaround for bug in libcuda.so that causes replayed graphs with
+    // certain topologies to be corrupted (kernels elided, internal syncs
+    // ignored) when replayed back to back without a sync in between.
+    // The bug is fixed in CUDA 11.4+.
+    AT_CUDA_CHECK(cudaDeviceSynchronize());
+  }
+#else
+  TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");
+#endif
+}
+
+void CustomizedCUDAGraph::reset() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  // I'd prefer these checks throw exceptions, not print warnings,
+  // but the destructor calls reset(), and at least one CI build
+  // refuses to compile with a throwing destructor.
+  //
+  // Instead of calling reset() in the destructor to clean up, I could
+  // call reset() in the __del__ method of a thin Python wrapper,
+  // in which case reset would be allowed to throw exceptions.
+  // But Stackoverflow does not like user-defined __del__.
+  // __del__ prevents Graph instances from EVER being garbage collected
+  // if they participate in a reference cycle.
+  // And exceptions thrown in __del__ only print a warning anyway.
+  //
+  // Calling reset() in the C++ destructor, with warnings instead of exceptions
+  // if calls fail, is the compromise we chose.
+  //
+  // If capture_begin, the capture, or capture_end failed at some point, this CUDAGraph, the
+  // generator, and the allocator could end up in all kinds of weird states depending where failure
+  // occurred. If the user catches the failure exception in a script, or is running in REPL or (god
+  // forbid) a Jupyter notebook, I don't see an easy way for reset() to gracefully fix all such
+  // possible error states.
+  if (has_graph_) {
+    // notifyCaptureDestroy may throw. How should we handle this?
+    c10::cuda::CUDACachingAllocator::releasePool(capture_dev_, mempool_id_);
+    C10_CUDA_CHECK_WARN(cudaGraphDestroy(graph_));
+    has_graph_ = false;
+  }
+  if (has_graph_exec_) {
+    C10_CUDA_CHECK_WARN(cudaGraphExecDestroy(graph_exec_));
+    has_graph_exec_ = false;
+  }
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+#endif
+}
+
+// Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
+MempoolId_t CustomizedCUDAGraph::pool() {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  TORCH_CHECK(has_graph_exec_, "Called CUDAGraph::pool() without a preceding successful capture.");
+#else
+  TORCH_CHECK(false,
+              "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0 or ROCM >= 5.3")
+#endif
+  return mempool_id_;
+}
+
+CustomizedCUDAGraph::~CustomizedCUDAGraph() { reset(); }
+
+}  // namespace at::cuda

--- a/csrc/custom_cudagraph/custom_cudagraph.h
+++ b/csrc/custom_cudagraph/custom_cudagraph.h
@@ -1,0 +1,106 @@
+// Copied and modified from
+// https://github.com/pytorch/pytorch/blob/v2.3.1/aten/src/ATen/cuda/CUDAGraph.h This implementation
+// enables efficient graph recapture, which is used to save memory without degrading performance.
+// When a graph is used periodically, its memory could not be released when the graph is unused.
+// Then to save memory, this graph should be destroyed and recaptured. However in original pytorch
+// implementation, recapturing the graph is expensive. This implementation uses
+// `cudaGraphExecUpdate` to recapture the graph efficiently. NOTE:
+// 1. This extension could only be compiled under torch version 2.3.1.
+//    Otherwise compile may fail due to incompatible APIs in pytorch source code.
+// 2. Compared to original pytorch CUDAGraph implementation, some features such as memory pool
+// sharing is disabled
+//    in this extension.
+//    It is also unsafe to mix the usage of this and the original pytorch one.
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
+#include <c10/core/Device.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <mutex>
+
+namespace at {
+
+struct CUDAGeneratorImpl;
+
+namespace cuda {
+
+// Standalone way to get a unique mempool id usable as a pool=... argument
+// to CUDAGraph::capture_begin
+TORCH_CUDA_CPP_API MempoolId_t graph_pool_handle();
+
+struct TORCH_CUDA_CPP_API CustomizedCUDAGraph {
+  CustomizedCUDAGraph();
+  ~CustomizedCUDAGraph();
+
+  static void inc_pending_event_queries();
+  static void dec_pending_event_queries();
+  static int num_pending_event_queries();
+  void capture_begin();
+  void capture_end();
+  void instantiate();
+  void destroy();
+  void update();
+  void replay();
+  void reset();
+  MempoolId_t pool();
+
+ protected:
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+  cudaGraph_t graph_ = NULL;
+  cudaGraphExec_t graph_exec_ = NULL;
+#endif
+
+  static std::atomic<int> pending_event_queries;
+
+  // internal states so reset() can do its best cleaning up
+  // Set to true in capture_end if cudaStreamEndCapture succeeded
+  // Set back to false soon after, when graph_ is consumed by cudaGraphInstantiate
+  // to create graph_exec_, then graph_ is deleted
+  bool has_graph_ = false;
+  // Set to true in capture_end if cudaGraphInstantiate succeeded
+  bool has_graph_exec_ = false;
+
+  // uuid of this instance's current capture, used to
+  // specify the pool.
+  CaptureId_t id_;
+
+  // the ID assigned by cuda during graph capture,
+  // used to identify when a stream is participating in capture
+  CaptureId_t capture_id_ = -1;
+
+  // uuid used to request a particular private mempool from CUDACachingAllocator.
+  // By default, this will be set to {id_, 0}.
+  //
+  // If capture_begin is called with "pool=other_graph.pool()", this graph's mempool_id_
+  // will be set to the other graph's mempool_id_, and therefore share a mempool with the
+  // other graph.
+  //
+  // If capture_begin is called with "pool=handle" where "handle" came from graph_pool_handle(),
+  // it will share a mempool with any other captures that used "pool=handle".
+  //
+  // Sharing a mempool across graphs saves memory, and it's safe if you
+  // know you'll replay those graphs in the same order you captured them.
+  MempoolId_t mempool_id_;
+
+  // Stream on which capture began
+  at::cuda::CUDAStream capture_stream_;
+
+  // Default generator on device where capture began
+  at::CUDAGeneratorImpl *capture_gen_;
+
+  // Device where capture occurred. Right now, for simplicity, we require all ops
+  // in a capture to run on the same device, but this is a limitation of CUDAGraph,
+  // not CUDA itself.  We can straightforwardly modify CUDAGraph to support multi-device
+  // captures if needed.
+  int capture_dev_;
+
+  // RNG state trackers
+  at::Tensor seed_extragraph_;
+  at::Tensor offset_extragraph_;
+  uint64_t wholegraph_increment_;
+};
+
+}  // namespace cuda
+}  // namespace at

--- a/csrc/custom_cudagraph/pybind.cpp
+++ b/csrc/custom_cudagraph/pybind.cpp
@@ -1,0 +1,14 @@
+#include <torch/extension.h>
+#include "custom_cudagraph.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  py::class_<at::cuda::CustomizedCUDAGraph>(m, "CustomizedCUDAGraph")
+      .def(py::init<>())
+      .def("capture_begin", &at::cuda::CustomizedCUDAGraph::capture_begin)
+      .def("capture_end", &at::cuda::CustomizedCUDAGraph::capture_end)
+      .def("replay", &at::cuda::CustomizedCUDAGraph::replay)
+      .def("reset", &at::cuda::CustomizedCUDAGraph::reset)
+      .def("instantiate", &at::cuda::CustomizedCUDAGraph::instantiate)
+      .def("destroy", &at::cuda::CustomizedCUDAGraph::destroy)
+      .def("update", &at::cuda::CustomizedCUDAGraph::update);
+};

--- a/realhf/impl/model/backend/pipe_runner.py
+++ b/realhf/impl/model/backend/pipe_runner.py
@@ -854,6 +854,11 @@ class PipelineRunner:
             *list(zip(*generate_output))
         )
 
+        if gconfig.use_cuda_graph:
+            for mbid in range(num_micro_batches):
+                cuda_graph_name = f"decoding_{mbid}"
+                cuda_graph.destroy(cuda_graph_name)
+
         return gen_tokens, log_probs, logits_mask, None, None
 
     def train_batch(

--- a/realhf/impl/model/parallelism/model_parallel/custom_all_reduce.py
+++ b/realhf/impl/model/parallelism/model_parallel/custom_all_reduce.py
@@ -1,6 +1,6 @@
 # Copied from the vLLM project: https://github.com/vllm-project/vllm
 import dataclasses
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from typing import Any, List, Optional
 
 import torch
@@ -40,62 +40,6 @@ logger = logging.getLogger(__name__)
 
 _CA_HANDLE = None
 _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
-
-
-@dataclasses.dataclass
-class GraphCaptureContext:
-    stream: torch.cuda.Stream
-
-
-@contextmanager
-def graph_capture():
-    """`graph_capture` is a context manager which should surround the code that
-    is capturing the CUDA graph.
-
-    Its main purpose is to ensure that the
-    some operations will be run after the graph is captured, before the graph
-    is replayed. It returns a `GraphCaptureContext` object which contains the
-    necessary data for the graph capture. Currently, it only contains the
-    stream that the graph capture is running on. This stream is set to the
-    current CUDA stream when the context manager is entered and reset to the
-    default stream when the context manager is exited. This is to ensure that
-    the graph capture is running on a separate stream from the default stream,
-    in order to explicitly distinguish the kernels to capture
-    from other kernels possibly launched on background in the default stream.
-    """
-    stream = torch.cuda.Stream()
-    graph_capture_context = GraphCaptureContext(stream)
-    maybe_ca_context = nullcontext() if _CA_HANDLE is None else _CA_HANDLE.capture()
-    with torch.cuda.stream(stream), maybe_ca_context:
-        yield graph_capture_context
-
-
-@dataclasses.dataclass
-class GraphCaptureContext:
-    stream: torch.cuda.Stream
-
-
-@contextmanager
-def graph_capture():
-    """`graph_capture` is a context manager which should surround the code that
-    is capturing the CUDA graph.
-
-    Its main purpose is to ensure that the
-    some operations will be run after the graph is captured, before the graph
-    is replayed. It returns a `GraphCaptureContext` object which contains the
-    necessary data for the graph capture. Currently, it only contains the
-    stream that the graph capture is running on. This stream is set to the
-    current CUDA stream when the context manager is entered and reset to the
-    default stream when the context manager is exited. This is to ensure that
-    the graph capture is running on a separate stream from the default stream,
-    in order to explicitly distinguish the kernels to capture
-    from other kernels possibly launched on background in the default stream.
-    """
-    stream = torch.cuda.Stream()
-    graph_capture_context = GraphCaptureContext(stream)
-    maybe_ca_context = nullcontext() if _CA_HANDLE is None else _CA_HANDLE.capture()
-    with torch.cuda.stream(stream), maybe_ca_context:
-        yield graph_capture_context
 
 
 def init_custom_ar() -> None:

--- a/realhf/impl/model/utils/cuda_graph.py
+++ b/realhf/impl/model/utils/cuda_graph.py
@@ -2,7 +2,8 @@ import dataclasses
 import gc
 import os
 import time
-from contextlib import nullcontext
+from collections import defaultdict
+from contextlib import contextmanager, nullcontext
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -17,6 +18,72 @@ logger = logging.getLogger("CUDAGraph")
 CUDA_GRAPH_STORAGE: Dict[str, torch.cuda.CUDAGraph] = dict()
 CUDA_GRAPH_INPUT_BUFFER: Dict[str, Dict[str, torch.Tensor]] = dict()
 CUDA_GRAPH_OUTPUT_BUFFER: Dict[str, Dict[str, torch.Tensor]] = dict()
+CUDA_GRAPH_FIRST_CAPTURE: Dict[str, bool] = defaultdict(lambda: True)
+CUDA_GRAPH_DESTROYED: Dict[str, bool] = defaultdict(lambda: False)
+
+try:
+    import realhf._C.custom_cudagraph as cudagraph
+
+    @contextmanager
+    def capture_context(graph, first_capture=True):
+        t0 = time.monotonic()
+        graph.capture_begin()
+        t1 = time.monotonic()
+        yield
+        t2 = time.monotonic()
+        graph.capture_end()
+        t3 = time.monotonic()
+        if first_capture:
+            graph.instantiate()
+        else:
+            graph.update()
+        t4 = time.monotonic()
+
+        print(
+            f"capture begin {t1-t0:.4f} run {t2-t1:.4f} capture end {t3-t2:.4f} "
+            f"{'instantiate' if first_capture else 'update'} {t4-t3:.4f}"
+        )
+
+except ImportError:
+    # fallback to pytorch cudagraph
+    cudagraph = None
+
+CAPTURE_STREAM = None
+# USE_CUSTOM_CUDAGRAPH = cudagraph is not None
+USE_CUSTOM_CUDAGRAPH = False
+_cudagraph_cls = (
+    cudagraph.CustomizedCUDAGraph if USE_CUSTOM_CUDAGRAPH else torch.cuda.CUDAGraph
+)
+
+# cudagraph=None
+
+
+@contextmanager
+def outer_capture_context(stream=None, no_grad=False):
+    """Context wrapped outside warmup and CUDAGraph capture context:
+    1. Alter stream from default.
+    2. Notify custom_all_reduce handle to enter capture mode.
+    3. Apply torch.no_grad context if required
+    """
+    if stream is None:
+        stream = torch.cuda.Stream()
+    maybe_ca_context = (
+        nullcontext()
+        if custom_all_reduce._CA_HANDLE is None
+        else custom_all_reduce._CA_HANDLE.capture()
+    )
+    maybe_no_grad = nullcontext() if not no_grad else torch.no_grad()
+    with torch.cuda.stream(stream), maybe_ca_context, maybe_no_grad:
+        yield
+
+
+def custom_all_reduce_assertion():
+    if not custom_all_reduce.is_initialized():
+        custom_all_reduce.init_custom_ar()
+    assert (
+        custom_all_reduce.is_initialized() or constants.model_parallel_world_size() == 1
+    )
+    assert not constants.sequence_parallel()
 
 
 def reinitialize_input_buffer(cuda_graph_name, new_buf):
@@ -44,10 +111,12 @@ def capture_func(
     input_buffer: Dict[str, Any],
     force_recapture: bool = False,
     no_grad: bool = False,
-) -> Tuple[torch.cuda.CUDAGraph, Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+) -> Tuple[Any, Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
     """Capture a function with cuda graph, store the graph and input/output
     buffers by name. The input/output metadata should match the inputs and
     outputs of function.
+
+    This function use pytorch original CUDAGraph implementation
 
     :param name: The identifier of the CUDAGraph to be captured/reused.
     :type name: str
@@ -63,58 +132,94 @@ def capture_func(
     global CUDA_GRAPH_STORAGE
     global CUDA_GRAPH_INPUT_BUFFER
     global CUDA_GRAPH_OUTPUT_BUFFER
-    if not force_recapture:
-        if name in CUDA_GRAPH_STORAGE:
-            reinitialize_input_buffer(name, input_buffer)
-            assert name in CUDA_GRAPH_INPUT_BUFFER
-            assert name in CUDA_GRAPH_OUTPUT_BUFFER
-            return (
-                CUDA_GRAPH_STORAGE[name],
-                CUDA_GRAPH_INPUT_BUFFER[name],
-                CUDA_GRAPH_OUTPUT_BUFFER[name],
+    global CUDA_GRAPH_FIRST_CAPTURE
+
+    # force_recapture = force_recapture or USE_CUSTOM_CUDAGRAPH
+    force_recapture = True
+    if not force_recapture and not CUDA_GRAPH_FIRST_CAPTURE[name]:
+        assert name in CUDA_GRAPH_STORAGE
+        assert name in CUDA_GRAPH_INPUT_BUFFER
+        assert name in CUDA_GRAPH_OUTPUT_BUFFER
+        reinitialize_input_buffer(name, input_buffer)
+        return (
+            CUDA_GRAPH_STORAGE[name],
+            CUDA_GRAPH_INPUT_BUFFER[name],
+            CUDA_GRAPH_OUTPUT_BUFFER[name],
+        )
+
+    custom_all_reduce_assertion()
+    stream = torch.cuda.Stream()
+    st = time.monotonic()
+    logger.info(f"Rank {dist.get_rank()}: Capturing CUDA graph for {name}")
+    first_capture = CUDA_GRAPH_FIRST_CAPTURE[name]
+
+    with outer_capture_context(stream, no_grad):
+        if first_capture:
+            func(**input_buffer)  # warmup
+            logger.info(
+                f"before clear cache before capture "
+                f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+                f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
+            )
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            logger.info(
+                f"after clear cache after capture "
+                f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+                f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
             )
 
-    if not custom_all_reduce.is_initialized():
-        custom_all_reduce.init_custom_ar()
-    assert (
-        custom_all_reduce.is_initialized() or constants.model_parallel_world_size() == 1
+        if first_capture or not USE_CUSTOM_CUDAGRAPH:
+            graph = _cudagraph_cls()
+        else:
+            graph = CUDA_GRAPH_STORAGE[name]
+
+        if USE_CUSTOM_CUDAGRAPH:
+            with capture_context(graph, first_capture=first_capture):
+                output = func(**input_buffer)
+        else:
+            with torch.cuda.graph(graph, stream=stream):
+                output = func(**input_buffer)
+
+    torch.cuda.synchronize()
+    logger.info(
+        f"Rank {dist.get_rank()}: Capturing CUDA graph {name} "
+        f"takes {time.monotonic() - st:.4f} seconds."
     )
-    assert not constants.sequence_parallel()
-
-    maybe_no_grad = nullcontext() if not no_grad else torch.no_grad()
-    st = time.monotonic()
-
-    with custom_all_reduce.graph_capture(), maybe_no_grad:
-        logger.info(f"Rank {dist.get_rank()}: Capturing CUDA graph for {name}")
-        func(**input_buffer)
-        torch.cuda.synchronize()
-
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            output = func(**input_buffer)
-
-        torch.cuda.synchronize()
-
-        logger.info(
-            f"Rank {dist.get_rank()}: Capturing CUDA graph {name} "
-            f"for decoding takes {time.monotonic() - st:.2f} seconds."
-        )
 
     assert torch.is_tensor(output)
     output_buffer = dict(output=output)
 
-    gc.collect()
-    torch.cuda.empty_cache()
-    gc.collect()
+    # logger.info(f"before clear cache after capture "
+    #             f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+    #             f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}")
+    # st = time.monotonic()
+    # gc.collect()
+    # torch.cuda.empty_cache()
+    # gc.collect()
+    # et = time.monotonic()
+    # logger.info(
+    #     f"clear cache after capture takes {et - st:.4f} seconds."
+    # )
+    logger.info(
+        f"after capture "
+        f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+        f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
+    )
 
     CUDA_GRAPH_STORAGE[name] = graph
     CUDA_GRAPH_INPUT_BUFFER[name] = input_buffer
     CUDA_GRAPH_OUTPUT_BUFFER[name] = output_buffer
+    CUDA_GRAPH_FIRST_CAPTURE[name] = False
+    CUDA_GRAPH_DESTROYED[name] = False
     return graph, input_buffer, output_buffer
 
 
 def input_buffer_handle(graph_name: str, tensor_name: str):
     if graph_name not in CUDA_GRAPH_INPUT_BUFFER:
+        return None
+    if USE_CUSTOM_CUDAGRAPH and CUDA_GRAPH_DESTROYED[graph_name]:
         return None
     if tensor_name not in CUDA_GRAPH_INPUT_BUFFER[graph_name]:
         raise ValueError(
@@ -127,6 +232,8 @@ def input_buffer_handle(graph_name: str, tensor_name: str):
 def output_buffer_handle(graph_name: str, tensor_name: str):
     if graph_name not in CUDA_GRAPH_OUTPUT_BUFFER:
         return None
+    if USE_CUSTOM_CUDAGRAPH and CUDA_GRAPH_DESTROYED[graph_name]:
+        return None
     if tensor_name not in CUDA_GRAPH_OUTPUT_BUFFER[graph_name]:
         raise ValueError(
             f"Tensor {tensor_name} not found in output buffer of graph {graph_name}, "
@@ -137,3 +244,53 @@ def output_buffer_handle(graph_name: str, tensor_name: str):
 
 def get_graph(name: str):
     return CUDA_GRAPH_STORAGE.get(name, None)
+
+
+def destroy(name):
+    if not USE_CUSTOM_CUDAGRAPH:
+        logger.info(
+            f"mem after generation: "
+            f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+            f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
+        )
+        return
+
+    global CUDA_GRAPH_STORAGE
+    global CUDA_GRAPH_INPUT_BUFFER
+    global CUDA_GRAPH_OUTPUT_BUFFER
+    global CUDA_GRAPH_FIRST_CAPTURE
+    global CUDA_GRAPH_DESTROYED
+
+    assert (
+        name in CUDA_GRAPH_STORAGE and not CUDA_GRAPH_FIRST_CAPTURE[name]
+    ), f"CUDAGraph {name} should be created before destroy."
+    assert CUDA_GRAPH_DESTROYED[name] is False, f"CUDAGraph {name} already destroyed."
+
+    logger.info(
+        f"before destroy "
+        f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+        f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
+    )
+
+    CUDA_GRAPH_STORAGE[name].destroy()
+    CUDA_GRAPH_INPUT_BUFFER[name] = None
+    CUDA_GRAPH_OUTPUT_BUFFER[name] = None
+    CUDA_GRAPH_DESTROYED[name] = True
+
+    logger.info(
+        f"after destroy "
+        f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+        f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}"
+    )
+
+    # st = time.monotonic()
+    # gc.collect()
+    # torch.cuda.empty_cache()
+    # gc.collect()
+    # et = time.monotonic()
+    # logger.info(
+    #     f"clear cache after destroy takes {et - st:.4f} seconds."
+    # )
+    # logger.info(f"after clear cache after destroy "
+    #             f"mem allocated: {torch.cuda.memory_allocated()/1024/1024:.4f}"
+    #             f"mem reserved: {torch.cuda.memory_reserved()/1024/1024:.4f}")

--- a/setup.py
+++ b/setup.py
@@ -253,6 +253,23 @@ if _is_cuda():
     )
     ext_modules.append(interval_op_cuda)
 
+    # FIXME: check version compatibility
+    if torch.__version__.startswith("2.3.1"):
+        print("torch==2.3.1, install custom cudagraph")
+        custom_cudagraph = CUDAExtension(
+            name="realhf._C.custom_cudagraph",
+            sources=[
+                "csrc/custom_cudagraph/custom_cudagraph.cpp",
+                "csrc/custom_cudagraph/pybind.cpp",
+            ],
+            extra_compile_args={
+                "cxx": CXX_FLAGS,
+                "nvcc": NVCC_FLAGS,
+            },
+            libraries=["cuda"],
+        )
+        ext_modules.append(custom_cudagraph)
+
 search_extension = setuptools.Extension(
     name="realhf._C.mdm_search",
     sources=[

--- a/tests/model/test_generate.py
+++ b/tests/model/test_generate.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("tests.test_generate")
 # with the model class name as the key and the path to the model weights as the value.
 MODEL_CLASS_TO_PATH = {
     "llama": "/lustre/public/pretrained_model_weights/Llama-2-7b-hf",
-    "gpt2": "/lustre/public/pretrained_model_weights/gpt2",
+    # "gpt2": "/lustre/public/pretrained_model_weights/gpt2",
 }
 _available_model_classes = []
 for k, v in MODEL_CLASS_TO_PATH.items():
@@ -37,10 +37,10 @@ def model_class(request):
 class GenerateTestParams:
     parallel: ParallelismConfig = dataclasses.field(default_factory=ParallelismConfig)
     huggingface: bool = False
-    prompt_len: int = 64
-    gen_len: int = 64
+    prompt_len: int = 128
+    gen_len: int = 128
     batch_size: int = 32
-    n_batches: int = 2
+    n_batches: int = 4  # FIXME
     use_cuda_graph: bool = False
 
     def identifier(self):
@@ -330,16 +330,19 @@ real_pp_cudagraph = GenerateTestParams(
 )
 
 
+# FIXME
 @pytest.mark.parametrize(
     "test_params1,test_params2,seq_acc_threshold,token_acc_threshold",
     [
-        (real_simple, huggingface, 0.8, 0.8),
-        (real_simple, real_cudagraph, 1.0, 1.0),
-        (real_simple, real_3d_parallel, 0.8, 0.8),
-        (real_mp, real_mp_cudagraph, 0.8, 0.8),
-        (real_dp, real_dp_cudagraph, 1.0, 1.0),
-        (real_pp, real_pp_cudagraph, 1.0, 1.0),
-        (real_3d_parallel, real_3d_parallel_cudagraph, 0.8, 0.8),
+        # (real_simple, huggingface, 0.8, 0.8),
+        # (real_simple, real_cudagraph, 1.0, 1.0),
+        # (real_simple, real_3d_parallel, 0.8, 0.8),
+        # (real_mp, real_mp_cudagraph, 0.8, 0.8),
+        # (real_dp, real_dp_cudagraph, 1.0, 1.0),
+        # (real_pp, real_pp_cudagraph, 1.0, 1.0),
+        # (real_3d_parallel, real_3d_parallel_cudagraph, 0.8, 0.8),
+        (real_cudagraph, real_simple, 1.0, 1.0),
+        # (real_mp_cudagraph, real_mp, 0.8, 0.8),
     ],
 )
 @pytest.mark.gpu


### PR DESCRIPTION
Change:
1. Add a custom CUDAGraph with `cudaGraphExecUpdate()` to replace original pytorch implementation. This will allow kv-cache to be released when not performing generation without introducing significant overhead.

This feature is not fully tested, marked as WIP.  