### PR TITLE
Fix bugs related to system-wise profiling.

### DIFF
--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -103,8 +103,8 @@ BASE_ENVIRONS = {
     # Whether to enable time mark to plot timelines.
     # "REAL_CUDA_TMARK": "1",
     # Whether to dump kernel time and trace for system-wise analysis.
-    "REAL_DUMP_KERNEL_TIME": str(1),
-    "REAL_DUMP_TRACE" : str(0),
+    "REAL_DUMP_KERNEL_TIME": str(0),
+    "REAL_DUMP_TRACE": str(0),
 }
 
 

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -101,7 +101,10 @@ BASE_ENVIRONS = {
     # https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573
     "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
     # Whether to enable time mark to plot timelines.
-    "REAL_CUDA_TMARK": "1",
+    # "REAL_CUDA_TMARK": "1",
+    # Whether to dump kernel time and trace for system-wise analysis.
+    "REAL_DUMP_KERNEL_TIME": str(1),
+    "REAL_DUMP_TRACE" : str(0),
 }
 
 

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -102,9 +102,6 @@ BASE_ENVIRONS = {
     "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
     # Whether to enable time mark to plot timelines.
     # "REAL_CUDA_TMARK": "1",
-    # Whether to dump kernel time and trace for system-wise analysis.
-    "REAL_DUMP_KERNEL_TIME": str(0),
-    "REAL_DUMP_TRACE": str(0),
 }
 
 

--- a/realhf/base/monitor.py
+++ b/realhf/base/monitor.py
@@ -466,8 +466,9 @@ COMPUTE_KERNEL_KEYS = [
 
 COMM_KERNEL_KEYS = [
     "c10d::",
-    "nccl::",
+    "nccl",
     "ncclDevKernel",
+    "vllm::cross_device_reduce",
 ]
 
 MEM_KERNEL_KEYS = [

--- a/realhf/base/monitor.py
+++ b/realhf/base/monitor.py
@@ -3,6 +3,7 @@ import dataclasses
 import enum
 import os
 import pickle
+import re
 import time
 from collections import defaultdict
 from statistics import mean
@@ -466,7 +467,7 @@ COMPUTE_KERNEL_KEYS = [
 
 COMM_KERNEL_KEYS = [
     "c10d::",
-    "nccl",
+    "nccl::",
     "ncclDevKernel",
     "vllm::cross_device_reduce",
 ]
@@ -502,6 +503,13 @@ class CUDAKernelTime:  # in us
                 continue
             if "waitevent" in x.key.lower():
                 print(x.key)
+            if re.match(r"^nccl:(?!:).*", x.key):
+                # I.e., filter out kernels starting with "nccl:"
+                # but the next character is not ":", e.g., "nccl:recv".
+                # This is the marker probably created by CUDAGraph.
+                # It is overlapped with the actual NCCL kernel.
+                # We don't want to count it twice.
+                continue
             if any(k in x.key for k in COMPUTE_KERNEL_KEYS):
                 compute_time += x.self_cuda_time_total
             elif any(k in x.key for k in COMM_KERNEL_KEYS):

--- a/realhf/impl/model/__init__.py
+++ b/realhf/impl/model/__init__.py
@@ -28,7 +28,7 @@ if torch.cuda.is_available():
     torch._C._jit_override_can_fuse_on_cpu(False)
     torch._C._jit_override_can_fuse_on_gpu(False)
     torch._C._jit_set_texpr_fuser_enabled(False)
-    torch._C._jit_set_nvfuser_enabled(True)
+    # torch._C._jit_set_nvfuser_enabled(True)  # disable the deprecated warning
     torch._C._debug_set_autodiff_subgraph_inlining(False)
 
 # Add HuggingFace hooks to ReaLModel.

--- a/realhf/impl/model/parallelism/model_parallel/mappings.py
+++ b/realhf/impl/model/parallelism/model_parallel/mappings.py
@@ -18,10 +18,12 @@ def _reduce(input_):
         return input_
 
     # All-reduce.
-    if custom_all_reduce.is_initialized():
-        out = custom_all_reduce.get_handle().custom_all_reduce(input_)
-        if out is not None:
-            return out
+    # NOTE: custom_all_reduce may randomly get stuck.
+    # Since pytorch all-reduce works fine with CUDAGraph, abandon custom_all_reduce.
+    # if custom_all_reduce.is_initialized():
+    #     out = custom_all_reduce.get_handle().custom_all_reduce(input_)
+    #     if out is not None:
+    #         return out
     torch.distributed.all_reduce(input_, group=constants.model_parallel_group())
     return input_
 

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import deepspeed
 import numpy as np
 import pynvml
+import tabulate
 import torch
 import torch.distributed as dist
 import torch.utils.data
@@ -769,18 +770,9 @@ class ModelWorker(worker_base.Worker):
         if isinstance(res, data_api.SequenceSample):
             res = res.meta()
 
-        # Log GPU utilization and memory statistics.
-        utilization = pynvml.nvmlDeviceGetUtilizationRates(self.__nvml_handle)
-        memory_info = pynvml.nvmlDeviceGetMemoryInfo(self.__nvml_handle)
-        total_memory = memory_info.total / (1024**2)  # Convert bytes to megabytes
-        used_memory = memory_info.used / (1024**2)
-        memory_usage_percentage = (used_memory / total_memory) * 100
-        logger.info(
-            f"Worker Index {self.__worker_index}, GPU {self.__pg_info.local_gpu_id}: "
-            f"Compute Utilization - {utilization.gpu}%, "
-            f"Total Memory - {total_memory:.2f}MB, Used Memory - {used_memory:.2f}MB, "
-            f"Memory Usage - {memory_usage_percentage:.2f}%"
-        )
+        # Monitoring info. There's an all-gather and an all-reduce
+        # over the parallelism group in this function.
+        self.__log_gpu_stats(request)
         return res
 
     @cuda_tmark("data_transfer", CUDATimeMarkType.comm)
@@ -957,3 +949,100 @@ class ModelWorker(worker_base.Worker):
                 logger.info("Received SIGINT, starting recover save")
 
         self.__recover_save()
+
+    def __log_gpu_stats(self, request: request_reply_stream.Payload):
+        # Log GPU utilization and memory statistics.
+        utilization = pynvml.nvmlDeviceGetUtilizationRates(self.__nvml_handle)  # bytes
+        memory_info = pynvml.nvmlDeviceGetMemoryInfo(self.__nvml_handle)  # bytes
+        torch_mem_stats = torch.cuda.memory_stats(0)
+
+        # All-gather hostname, gpu ID, and stats.
+        hostname = socket.gethostname()
+        hostname_len = len(hostname)
+        assert hostname_len < 64, "hostname should have more than 64 chars"
+        # Encode hostnames into long.
+        hostname_np = np.fromstring(
+            hostname + "x" * (64 - len(hostname)), dtype=np.int64
+        )
+        local_mem_stats = torch.tensor(
+            [hostname_len, self.__pg_info.local_gpu_id]
+            + hostname_np.tolist()
+            + [
+                torch_mem_stats["allocated_bytes.all.peak"],
+                torch_mem_stats["reserved_bytes.all.peak"],
+                memory_info.used,
+            ],
+            dtype=torch.long,
+            device="cuda",
+        )  # length 2 + 8 + 3 = 13
+        mem_stats = local_mem_stats.new_zeros(
+            size=(
+                dist.get_world_size(constants.parallelism_group()),
+                local_mem_stats.shape[0],
+            )
+        )
+        # All-gather memory stats.
+        dist.all_gather_into_tensor(
+            mem_stats, local_mem_stats, group=constants.parallelism_group()
+        )
+        mem_stats = mem_stats.cpu().numpy()
+
+        # All-reduce utilization.
+        gpu_compute_util = torch.tensor(
+            utilization.gpu, dtype=torch.float32, device="cuda"
+        )
+        dist.all_reduce(gpu_compute_util, group=constants.parallelism_group())
+        gpu_compute_util = gpu_compute_util.item() / dist.get_world_size(
+            constants.parallelism_group()
+        )
+
+        def _decode_hostname(idx):
+            hn_np = mem_stats[idx, 2 : 2 + 8]
+            l = mem_stats[idx, 0]
+            return hn_np.tobytes().decode("utf-8")[:l]
+
+        def _decode_gpu_id(idx):
+            return f"{_decode_hostname(idx)}:{mem_stats[idx, 1]}"
+
+        max_used_gpu_id = _decode_gpu_id(np.argmax(mem_stats[:, -1]))
+        max_reserved_gpu_id = _decode_gpu_id(np.argmax(mem_stats[:, -2]))
+        max_tensor_gpu_id = _decode_gpu_id(np.argmax(mem_stats[:, -3]))
+
+        # NOTE: We only log the peak memory because it's
+        # the most important for detecting OOM issues.
+        headers = [
+            " ",
+            "TotalMem",
+            "PeakUsedMem",
+            "PeakTensorMem",
+            "PeakReservedMem",
+            "MaxMemUtil",
+            "AvgComputeUtil",
+        ]
+        line1 = [
+            "Value",
+            f"{memory_info.total / 1024**2:.2f}MB",
+            f"{max(mem_stats[:, -1]) / 1024**2:.2f}MB",
+            f"{max(mem_stats[:, -3]) / 1024**2:.2f}MB",
+            f"{max(mem_stats[:, -2]) / 1024**2:.2f}MB",
+            f"{max(mem_stats[:, -1]) / memory_info.total * 100:.2f}%",
+            f"{gpu_compute_util:.2f}%",
+        ]
+        line2 = [
+            "GPU ID",
+            "-",
+            max_used_gpu_id,
+            max_tensor_gpu_id,
+            max_reserved_gpu_id,
+            max_used_gpu_id,
+            "-",
+        ]
+
+        if self._dp_rank == 0 and self._is_dp_head:
+            logger.info(
+                f"Aggregated GPU memory stats after MFC `{request.handle_name}`"
+                f" within model `{request.handler.model_name}`:\n"
+                + tabulate.tabulate(
+                    [headers, line1, line2], headers="firstrow", tablefmt="fancy_grid"
+                )
+            )

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -679,11 +679,11 @@ class ModelWorker(worker_base.Worker):
             if _enable_profiler:
                 if self._dp_rank == 0 and self._is_dp_head:
                     blogger.info(
-                        f"RPC {rpc.name} pure execution time "
-                        f"w/o profiler: {time.perf_counter() - profiler_tik:.2f} secs."
+                        f"RPC {rpc.name} execution time "
+                        f"w/o external data processing: {time.perf_counter() - profiler_tik:.2f} secs."
                     )
                     collect_tik = time.perf_counter()
-                    blogger.debug(
+                    blogger.info(
                         f"Collecting system metrics from the profiler. "
                         "This may take for a while..."
                     )
@@ -716,7 +716,7 @@ class ModelWorker(worker_base.Worker):
                         os.path.join(trace_dir, f"{rpc.name}_r{dist.get_rank()}.json")
                     )
                 if self._dp_rank == 0 and self._is_dp_head:
-                    blogger.debug(
+                    blogger.info(
                         f"System metrics collected. Time consumption:"
                         f" {time.perf_counter() - collect_tik:.2f} secs."
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ tqdm
 transformers==4.42.3
 networkx==3.3
 matplotlib
+tabulate


### PR DESCRIPTION
Changes:

1. The environment variable "REAL_CUDA_TMARK" defaults to False since it introduces cuda synchronization points.
2. Fix the names of the kernel time counter to make it compatible with CUDAGraph.
3. Fix CUDAGraph capture and destroy in the pipeline runner. Capturing is now conducted in the first decoding step rather than the prefill step. It will reduce the length of the critical path. Graph is safely destroyed in all stages.
4. Disable custom-all-reduce in CUDAGraph, as it is the root cause of stuck.
5. Add profiling utilities in the model worker and a fancier GPU utilization log. When `REAL_DUMP_KERNEL_TIME` and `REAL_DUMP_TRACE` are set, traces and kernel times are dumped into the experiment log dir.