### PR TITLE
[Patch Fixes] Fix several bugs and unintended behaviors.

### DIFF
--- a/examples/customized_exp/ppo_ref_ema.py
+++ b/examples/customized_exp/ppo_ref_ema.py
@@ -20,7 +20,9 @@ class PPORefEMAConfig(PPOConfig):
         rpc_allocs = self._get_rpc_allocations()
 
         resolve_replica_ids(rpc_allocs)
-        resolve_rpc_hooks(rpc_allocs)  # inplace modify MFCDefs in rpc allocations
+        resolve_rpc_hooks(
+            rpc_allocs, self.models
+        )  # inplace modify MFCDefs in rpc allocations
 
         pprint.pprint(rpc_allocs)
 

--- a/examples/customized_exp/ppo_sentiment.py
+++ b/examples/customized_exp/ppo_sentiment.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("Sentiment PPO example")
 class SentimentScoringInterface(model_api.ModelInterface):
 
     def __post_init__(self):
-        path = "/lustre/fw/pretrained/distilbert-base-uncased-finetuned-sst-2-english/"
+        path = "/path/to/model"
         self.score_model = (
             transformers.AutoModelForSequenceClassification.from_pretrained(path).cuda()
         )

--- a/examples/customized_exp/ppo_sentiment.py
+++ b/examples/customized_exp/ppo_sentiment.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Optional
 
 import colorama
 import torch
@@ -15,6 +16,7 @@ from realhf.api.core.system_api import ExperimentConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.apps.quickstart import main
 from realhf.base import logging
+from realhf.base.datapack import flat2d
 from realhf.experiments.common.ppo_exp import PPOConfig
 
 logger = logging.getLogger("Sentiment PPO example")
@@ -24,7 +26,7 @@ logger = logging.getLogger("Sentiment PPO example")
 class SentimentScoringInterface(model_api.ModelInterface):
 
     def __post_init__(self):
-        path = "/path/to/model"
+        path = "/lustre/fw/pretrained/distilbert-base-uncased-finetuned-sst-2-english/"
         self.score_model = (
             transformers.AutoModelForSequenceClassification.from_pretrained(path).cuda()
         )
@@ -34,11 +36,14 @@ class SentimentScoringInterface(model_api.ModelInterface):
 
     @torch.no_grad()
     def inference(
-        self, model: model_api.Model, input_: SequenceSample
+        self,
+        model: model_api.Model,
+        input_: SequenceSample,
+        n_mbs: Optional[int] = None,
     ) -> SequenceSample:
         device = model.device
         packed_input_ids: torch.Tensor = input_.data["packed_input_ids"]
-        seqlens_cpu = torch.cat(input_.seqlens["packed_input_ids"])
+        seqlens_cpu = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
         max_seqlen = int(max(seqlens_cpu))
         bs = input_.bs
 

--- a/examples/new_algorithms/grpo/grpo.sh
+++ b/examples/new_algorithms/grpo/grpo.sh
@@ -30,6 +30,7 @@ python3 examples/new_algorithms/grpo/grpo_exp.py grpo \
     n_nodes=1 \
     ppo.gen.max_new_tokens=512 \
     ppo.gen.min_new_tokens=512 \
+    ppo.gen.use_cuda_graph=True \
     ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
     ppo.ppo_n_minibatches=4 \
     ppo.reward_output_scaling=1.0 ppo.adv_norm=False

--- a/examples/new_algorithms/grpo/grpo_exp.py
+++ b/examples/new_algorithms/grpo/grpo_exp.py
@@ -58,16 +58,6 @@ class GRPOConfig(CommonExperimentConfig):
             adaptive_kl_ctl=self.ppo.use_adaptive_kl_ctl,
         )
 
-        if self.ppo.gen.use_cuda_graph and (
-            self.actor_train.parallel != self.actor_gen.parallel
-        ):
-            raise ValueError(
-                "CUDA graph cannot be used with parameter reallocation "
-                "because CUDA graph requires pinned parameter memory. "
-                "Either set use_cuda_graph=False or set identical parallel "
-                "strategies for actor_train and actor_gen."
-            )
-
     @property
     def models(self) -> Dict[str, ModelTrainEvalConfig]:
         # role to config

--- a/examples/new_algorithms/grpo/grpo_interface.py
+++ b/examples/new_algorithms/grpo/grpo_interface.py
@@ -292,21 +292,32 @@ class GRPOInterface(model_api.ModelInterface):
         module = model.module
         module.eval()
 
-        logits = module.forward(input_=input_, num_micro_batches=n_mbs)
-        if logits is None:
-            return None
-
-        logits /= self.generation_config.temperature
-        if (
-            "packed_logits_mask" in input_.data
-            and input_.data["packed_logits_mask"] is not None
-        ):
-            apply_logits_mask(logits, input_.data["packed_logits_mask"])
         input_lens = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
         cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-        logprobs = gather_packed_shifted_log_probs(
-            logits, cu_seqlens, input_.data["packed_input_ids"]
+
+        # This post_hook will gather log probabilities in mini-batches,
+        # reducing peak memory usage.
+        def calc_logprobs(logits, input_):
+            logits /= self.generation_config.temperature
+            if (
+                "packed_logits_mask" in input_.data
+                and input_.data["packed_logits_mask"] is not None
+            ):
+                apply_logits_mask(logits, input_.data["packed_logits_mask"])
+
+            logprobs = gather_packed_shifted_log_probs(
+                logits, cu_seqlens, input_.data["packed_input_ids"]
+            )
+            return logprobs
+
+        logprobs = module.forward(
+            input_=input_,
+            num_micro_batches=n_mbs,
+            post_hook=calc_logprobs,
         )
+        if logprobs is None:
+            return None
+
         res = SequenceSample(
             keys=["packed_ref_logprobs"],
             ids=input_.ids,

--- a/examples/new_algorithms/grpo/grpo_interface.py
+++ b/examples/new_algorithms/grpo/grpo_interface.py
@@ -292,12 +292,11 @@ class GRPOInterface(model_api.ModelInterface):
         module = model.module
         module.eval()
 
-        input_lens = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
-        cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-
         # This post_hook will gather log probabilities in mini-batches,
         # reducing peak memory usage.
         def calc_logprobs(logits, input_):
+            input_lens = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
+            cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
             logits /= self.generation_config.temperature
             if (
                 "packed_logits_mask" in input_.data

--- a/examples/new_algorithms/reinforce/reinforce.sh
+++ b/examples/new_algorithms/reinforce/reinforce.sh
@@ -52,6 +52,7 @@ python3 examples/new_algorithms/reinforce/reinforce_exp.py reinforce \
     dataset.train_bs_n_seqs=512 \
     gen.max_new_tokens=512 \
     gen.min_new_tokens=512 \
+    gen.use_cuda_graph=True \
     gen.top_p=0.9 gen.top_k=5000 \
     allocation_mode=manual \
     n_nodes=1 \

--- a/examples/new_algorithms/reinforce/reinforce_exp.py
+++ b/examples/new_algorithms/reinforce/reinforce_exp.py
@@ -50,19 +50,6 @@ class ReinforceConfig(CommonExperimentConfig):
     discount: float = 0.99
     adv_norm: bool = True
 
-    def __post_init__(self):
-
-        if self.gen.use_cuda_graph and (
-            self.actor_train.parallel != self.greedy_gen.parallel
-            or self.actor_train.parallel != self.sample_gen.parallel
-        ):
-            raise ValueError(
-                "CUDA graph cannot be used with parameter reallocation "
-                "because CUDA graph requires pinned parameter memory. "
-                "Either set use_cuda_graph=False or set identical parallel "
-                "strategies for training and generation."
-            )
-
     @property
     def models(self) -> Dict[str, ModelTrainEvalConfig]:
         # role to config

--- a/examples/scripts/distributed_ray/ppo.sh
+++ b/examples/scripts/distributed_ray/ppo.sh
@@ -64,6 +64,7 @@ python3 -m realhf.apps.quickstart ppo \
     dataset.train_bs_n_seqs=128 \
     ppo.gen.max_new_tokens=512 \
     ppo.gen.min_new_tokens=512 \
+    ppo.gen.use_cuda_graph=True \
     ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
     ppo.ppo_n_minibatches=4 \
     ppo.kl_ctl=0.1 \

--- a/examples/scripts/distributed_slurm/ppo.sh
+++ b/examples/scripts/distributed_slurm/ppo.sh
@@ -65,6 +65,7 @@ python3 -m realhf.apps.quickstart ppo \
     dataset.train_bs_n_seqs=128 \
     ppo.gen.max_new_tokens=512 \
     ppo.gen.min_new_tokens=512 \
+    ppo.gen.use_cuda_graph=True \
     ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
     ppo.ppo_n_minibatches=4 \
     ppo.kl_ctl=0.1 \

--- a/examples/scripts/local/gen.sh
+++ b/examples/scripts/local/gen.sh
@@ -16,9 +16,9 @@ python3 -m realhf.apps.quickstart gen \
     allocation_mode=manual \
     model.type._class=$MODEL_FAMILY \
     model.path=$SFT_MODEL_PATH \
-    dataset.path=/lustre/fw/datasets/imdb/rl/ppo_prompt.jsonl \
+    dataset.path=/lustre/fw/datasets/imdb/rl/ppo_prompt-small.jsonl \
     dataset.max_prompt_len=1024 \
-    dataset.train_bs_n_seqs=128 \
+    dataset.train_bs_n_seqs=100 \
     allocation.parallel.pipeline_parallel_size=1 \
     allocation.parallel.model_parallel_size=2 \
     allocation.parallel.data_parallel_size=4 \

--- a/examples/scripts/local/ppo.sh
+++ b/examples/scripts/local/ppo.sh
@@ -64,6 +64,7 @@ python3 -m realhf.apps.quickstart ppo \
     dataset.train_bs_n_seqs=128 \
     ppo.gen.max_new_tokens=512 \
     ppo.gen.min_new_tokens=512 \
+    ppo.gen.use_cuda_graph=True \
     ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
     ppo.ppo_n_minibatches=4 \
     ppo.kl_ctl=0.1 \

--- a/examples/scripts/local/ppo_manual.sh
+++ b/examples/scripts/local/ppo_manual.sh
@@ -74,6 +74,7 @@ python3 -m realhf.apps.quickstart ppo \
     ppo.gen.max_new_tokens=512 \
     ppo.gen.min_new_tokens=512 \
     ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
+    ppo.gen.use_cuda_graph=True \
     ppo.ppo_n_minibatches=4 \
     ppo.kl_ctl=0.1 \
     ppo.value_eps_clip=0.2 \

--- a/examples/scripts/local/ppo_minibatched.sh
+++ b/examples/scripts/local/ppo_minibatched.sh
@@ -1,0 +1,80 @@
+# MODEL_FAMILY specifies how the pretrained checkpoint is loaded, e.g., as a LLaMA model or a GPT model.
+# You can specify different model families for the SFT and the RW model, but you need to
+# re-tokenize the sequences if necessary.
+MODEL_FAMILY=llama
+
+# SFT_MODEL_PATH and RW_MODEL_PATH are the saved SFT and RW checkpoints.
+# ReaL saves checkpoints with the same format as HuggingFace,
+# so you don't need to convert or split checkpoints explicitly.
+# You can also directly use the pre-trained HuggingFace checkpoint, but this
+# will not ensure the optimal algorithm performance.
+SFT_MODEL_PATH=/lustre/aigc/llm/checkpoints/fw/quickstart-sft/$MODEL_FAMILY-local-manual/default/epoch7epochstep5globalstep50/
+RW_MODEL_PATH=/lustre/aigc/llm/checkpoints/fw/quickstart-rw/$MODEL_FAMILY-ray-manual/default/epoch1epochstep10globalstep10/
+
+# Option 1: The experiment runs locally with subprocesses.
+MODE=local
+# Option 2: The experiment runs in a Ray cluster
+# MODE=ray
+# Option 3: The experiment runs in a SLURM + pyxis cluster
+# Using the slurm mode requires a cluster spec file
+# and setting CLUSTER_SPEC_PATH to the path of it.
+# MODE=slurm
+
+# `experiment_name` and `trial_name` can be arbitrary.
+# Logs and saved checkpoints will be indexed by them.
+EXP_NAME=quickstart-ppo
+TRIAL_NAME=$MODEL_FAMILY-$MODE-heuristic
+
+# We use the "heuristic" allocation mode here to automatically determine the parallelism strategy
+# for each model function call, i.e., actor generation, critic inference, actor train, etc.
+# The number of GPUs is `n_nodes` * `n_gpus_per_node` (not set explictly here, defaults to 8).
+# ReaL will make full use of these available GPUs to design allocations.
+# This does not ensure the optimal throughput, but it is a good starting point.
+
+# The `heuristic` allocation mode is not ensured to run with every model configurations.
+# For example, if the vocabulary size is an odd number, the model parallelism may not work.
+# In these cases, you can use the `ppo_manual.sh` to specify the parallelism strategy manually.
+
+# The `ppo` subcommand specifies that this is a PPO experiment.
+# The `save_freq_steps` is set to `null` to disable saving checkpoints.
+# Enable it if you want to save checkpoints.
+# The `ppo` option is used to control the generation and PPO algorithm hyperparameters.
+# Note that the performance of PPO is sensitive to the the pre-trained model and hyperparameters.
+# It's the user's responsibility to tune them appropriately.
+python3 -m realhf.apps.quickstart ppo \
+    mode=$MODE \
+    experiment_name=$EXP_NAME \
+    trial_name=$TRIAL_NAME \
+    exp_ctrl.total_train_epochs=1 \
+    exp_ctrl.save_freq_steps=null \
+    n_nodes=1 \
+    allocation_mode=heuristic \
+    actor.type._class=$MODEL_FAMILY \
+    actor.path=$SFT_MODEL_PATH \
+    critic.type._class=$MODEL_FAMILY \
+    critic.type.is_critic=True \
+    critic.path=$RW_MODEL_PATH \
+    ref.type._class=$MODEL_FAMILY \
+    ref.path=$SFT_MODEL_PATH \
+    rew.type._class=$MODEL_FAMILY \
+    rew.type.is_critic=True \
+    rew.path=$RW_MODEL_PATH \
+    dataset.path=/lustre/fw/datasets/imdb/rl/ppo_prompt.jsonl \
+    dataset.max_prompt_len=128 \
+    dataset.train_bs_n_seqs=1024 \
+    ppo.gen.max_new_tokens=512 \
+    ppo.gen.min_new_tokens=512 \
+    ppo.gen.use_cuda_graph=True \
+    ppo.gen.force_no_logits_mask=True \
+    ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
+    ppo.ppo_n_minibatches=4 \
+    ppo.kl_ctl=0.1 \
+    ppo.value_eps_clip=0.2 \
+    ppo.reward_output_scaling=1.0 \
+    ppo.adv_norm=True ppo.value_norm=True \
+    actor_gen.n_mbs=2 \
+    actor_train.n_mbs=4 \
+    critic_inf.n_mbs=4 \
+    critic_train.n_mbs=4 \
+    rew_inf.n_mbs=2 \
+    ref_inf.n_mbs=8

--- a/realhf/api/core/data_api.py
+++ b/realhf/api/core/data_api.py
@@ -48,7 +48,10 @@ def load_hf_tokenizer(
     if padding_side is not None:
         kwargs["padding_side"] = padding_side
     tokenizer = transformers.AutoTokenizer.from_pretrained(
-        model_name_or_path, fast_tokenizer=fast_tokenizer, **kwargs
+        model_name_or_path,
+        fast_tokenizer=fast_tokenizer,
+        trust_remote_code=True,
+        **kwargs,
     )
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id

--- a/realhf/api/core/data_api.py
+++ b/realhf/api/core/data_api.py
@@ -631,10 +631,17 @@ def load_shuffle_split_dataset(
             with open(dataset_path, "r") as f:
                 data = json.load(f)
         else:
-            raise NotImplementedError(f"Unkown dataset extension: {dataset_path}")
+            raise NotImplementedError(f"Unknown dataset extension: {dataset_path}")
     else:
         assert dataset_builder is not None
         data = dataset_builder()
+
+    if any("id" not in d for d in data):
+        logger.warning(
+            f'Key "id" not found in the dataset. Use indices as dataset IDs.'
+        )
+        for idx, d in enumerate(data):
+            d["id"] = idx
 
     datasize_per_rank = len(data) // util.world_size
     shuffle_indices = get_shuffle_indices(

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -272,7 +272,7 @@ class FinetuneSpec:
 
 
 class PipelinableEngine(abc.ABC):
-    @abc.abstractmethod
+
     def train_batch(
         self,
         input_: SequenceSample,
@@ -300,7 +300,6 @@ class PipelinableEngine(abc.ABC):
             num_micro_batches=num_micro_batches,
         )
 
-    @abc.abstractmethod
     def forward(
         self,
         input_: SequenceSample,
@@ -310,7 +309,6 @@ class PipelinableEngine(abc.ABC):
     ):
         raise NotImplementedError()
 
-    @abc.abstractmethod
     def generate(
         self,
         input_: SequenceSample,

--- a/realhf/api/core/system_api.py
+++ b/realhf/api/core/system_api.py
@@ -184,6 +184,11 @@ class ExperimentSaveEvalControl:
     :param benchmark_steps: Terminate the training after this number of steps.
         Used by system benchmark only. Please leave it to None for normal training.
     :type benchmark_steps: Optional[int]
+    :param save_eval_timeout: Timeout in seconds for saving and evaluation.
+        Will be used for the last step of the experiment. The master worker will sleep
+        for `save_eval_timeout` seconds to wait all save or evaluations to finish.
+        Defaults to 120 seconds.
+    :type save_eval_timeout: int
     """
 
     total_train_epochs: int = 1
@@ -197,6 +202,8 @@ class ExperimentSaveEvalControl:
     eval_freq_secs: Optional[int] = None
     # benchmark
     benchmark_steps: Optional[int] = None
+    # Graceful exit
+    save_eval_timeout: int = 120
 
 
 @dataclasses.dataclass

--- a/realhf/api/core/system_api.py
+++ b/realhf/api/core/system_api.py
@@ -184,11 +184,6 @@ class ExperimentSaveEvalControl:
     :param benchmark_steps: Terminate the training after this number of steps.
         Used by system benchmark only. Please leave it to None for normal training.
     :type benchmark_steps: Optional[int]
-    :param save_eval_timeout: Timeout in seconds for saving and evaluation.
-        Will be used for the last step of the experiment. The master worker will sleep
-        for `save_eval_timeout` seconds to wait all save or evaluations to finish.
-        Defaults to 120 seconds.
-    :type save_eval_timeout: int
     """
 
     total_train_epochs: int = 1
@@ -202,8 +197,6 @@ class ExperimentSaveEvalControl:
     eval_freq_secs: Optional[int] = None
     # benchmark
     benchmark_steps: Optional[int] = None
-    # Graceful exit
-    save_eval_timeout: int = 120
 
 
 @dataclasses.dataclass

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -472,7 +472,9 @@ class CommonExperimentConfig(Experiment):
         rpc_allocs = self._get_rpc_allocations()
 
         resolve_replica_ids(rpc_allocs)
-        resolve_rpc_hooks(rpc_allocs)  # inplace modify MFCDefs in rpc allocations
+        resolve_rpc_hooks(
+            rpc_allocs, self.models
+        )  # inplace modify MFCDefs in rpc allocations
 
         pprint.pprint(rpc_allocs)
 

--- a/realhf/experiments/common/gen_exp.py
+++ b/realhf/experiments/common/gen_exp.py
@@ -6,6 +6,7 @@ from realhf.api.core.config import (
     ModelInterfaceType,
     ModelName,
 )
+from realhf.api.core.data_api import DatasetUtility, load_hf_tokenizer
 from realhf.api.core.dfg import MFCDef
 from realhf.api.core.model_api import GenerationHyperparameters
 from realhf.api.quickstart.dataset import PromptOnlyDatasetConfig
@@ -43,6 +44,35 @@ class GenerationConfig(CommonExperimentConfig):
     )
     allocation: MFCConfig = dataclasses.field(default_factory=MFCConfig)
 
+    output_file: str = "output.jsonl"
+
+    def __post_init__(self):
+        from realhf.impl.dataset.prompt_dataset import PromptDataset
+
+        util = DatasetUtility(
+            seed=0,
+            ddp_rank=0,
+            world_size=1,
+            tokenizer=load_hf_tokenizer(self.model.path),
+        )
+        d = PromptDataset(
+            util, max_length=self.dataset.max_prompt_len, dataset_path=self.dataset.path
+        )
+        if len(d) % self.dataset.train_bs_n_seqs != 0:
+            raise ValueError(
+                f"The size of the dataset must be a multiple of batch size for generation. "
+                f"Otherwise the final batch will be dropped. Please pad your dataset size with random prompts. "
+                f"Current dataset size: {len(d)}, batch size: {self.dataset.train_bs_n_seqs}."
+            )
+        if self.output_file is not None:
+            if not self.output_file.endswith(".jsonl"):
+                raise ValueError("Output path must end with .jsonl")
+            if "/" in self.output_file:
+                raise ValueError(
+                    "Output path must not contain '/'. It should be a simple "
+                    "filename that will be saved to the logging directory."
+                )
+
     @property
     def models(self):
         return {
@@ -52,7 +82,8 @@ class GenerationConfig(CommonExperimentConfig):
     @property
     def rpcs(self):
         interface = ModelInterfaceAbstraction(
-            "generation", args={"generation_config": self.gen}
+            "generation",
+            args={"generation_config": self.gen, "output_file": self.output_file},
         )
         gen = MFCDef(
             name="gen",

--- a/realhf/experiments/common/ppo_exp.py
+++ b/realhf/experiments/common/ppo_exp.py
@@ -234,16 +234,6 @@ class PPOConfig(CommonExperimentConfig):
             value_norm_eps=self.ppo.value_norm_eps,
         )
 
-        if self.ppo.gen.use_cuda_graph and (
-            self.actor_train.parallel != self.actor_gen.parallel
-        ):
-            raise ValueError(
-                "CUDA graph cannot be used with parameter reallocation "
-                "because CUDA graph requires pinned parameter memory. "
-                "Either set use_cuda_graph=False or set identical parallel "
-                "strategies for actor_train and actor_gen."
-            )
-
     @property
     def models(self) -> Dict[str, ModelTrainEvalConfig]:
         # role to config

--- a/realhf/experiments/common/utils.py
+++ b/realhf/experiments/common/utils.py
@@ -83,7 +83,9 @@ def make_train_backend_config(
         if model_cfg.zero_stage == 3:
             raise ValueError("Zero stage 3 is not supported in Megatron backend.")
         if model_cfg.zero_stage == 2:
-            logger.warning("Megatron does not ZeRO stage 2. Degenerates to stage 1.")
+            logger.warning(
+                "Megatron does not support ZeRO stage 2. Degenerates to stage 1."
+            )
             model_cfg.zero_stage = 1
         return ModelBackendAbstraction(
             "megatron",

--- a/realhf/experiments/common/utils.py
+++ b/realhf/experiments/common/utils.py
@@ -159,8 +159,8 @@ def resolve_rpc_hooks(
                     and device_mesh == other.device_mesh
                 ):
                     continue
-                self_config = model_configs[rpc.model_name]
-                other_config = model_configs[other.rpc.model_name]
+                self_config = model_configs[rpc.model_name.role]
+                other_config = model_configs[other.rpc.model_name.role]
                 if (
                     self_config.backend == "deepspeed"
                     or other_config.backend == "deepspeed"

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -166,7 +166,7 @@ class PipeTrainSetForDeepSpeed(PipeTrainInstrSet):
             )
 
 
-class ReaLDeepSpeedEngine:
+class ReaLDeepSpeedEngine(model_api.PipelinableEngine):
 
     def __init__(
         self,
@@ -258,20 +258,16 @@ class ReaLDeepSpeedEngine:
             return stat
 
     @torch.no_grad()
-    def eval_batch(
-        self,
-        input_: SequenceSample,
-        loss_fn: Callable,
-        num_micro_batches: Optional[int] = None,
-    ):
-        return self.inf_engine.eval_batch(input_, loss_fn, num_micro_batches)
-
     def forward(
         self,
         input_: SequenceSample,
         num_micro_batches: Optional[int] = None,
+        post_hook: Callable[[torch.Tensor, SequenceSample], Any] | None = None,
+        aggregate_fn: Callable[[List[Any]], Any] = torch.cat,
     ):
-        return self.inf_engine.forward(input_, num_micro_batches)
+        return self.inf_engine.forward(
+            input_, num_micro_batches, post_hook=post_hook, aggregate_fn=aggregate_fn
+        )
 
     @torch.no_grad()
     def generate(

--- a/realhf/impl/model/backend/deepspeed.py
+++ b/realhf/impl/model/backend/deepspeed.py
@@ -201,34 +201,21 @@ class ReaLDeepSpeedEngine(model_api.PipelinableEngine):
         version_steps: int,
         num_micro_batches: Optional[int] = None,
     ):
+        if num_micro_batches is None:
+            num_micro_batches = 1
         if constants.pipe_parallel_world_size() > 1:
             # Fusing the minibatched forward-backward in a pipeline training schedule.
-            if num_micro_batches is not None:
-                if (
-                    num_micro_batches < self.pipe_runner.default_train_mbs
-                    and constants.parallelism_rank() == 0
-                ):
-                    logger.warning(
-                        "When training with pipeline parallel, num micro batches should be "
-                        "larger than 2 x num_pipeline_stages to avoid idle time. "
-                        f"Setting num_micro_batches to {self.pipe_runner.default_train_mbs}"
-                    )
-                num_micro_batches = max(
-                    num_micro_batches, self.pipe_runner.default_train_mbs
-                )
-            else:
-                num_micro_batches = self.pipe_runner.default_train_mbs
             instr_set = PipeTrainSetForDeepSpeed(self.ds_engine)
+            # NOTE: When training with pipeline parallel, num micro batches should be
+            # larger than 2 x num_pipeline_stages to avoid idle time.
             return self.pipe_runner.train_batch(
                 instr_set=instr_set,
                 input_=input_,
                 loss_fn=loss_fn,
                 version_steps=version_steps,
-                n_pp_mbs=num_micro_batches,
+                n_pp_mbs=self.pipe_runner.default_train_mbs * num_micro_batches,
             )
         else:
-            if num_micro_batches is None:
-                num_micro_batches = 1
             self.ds_engine._config.gradient_accumulation_steps = num_micro_batches
             self.ds_engine.set_gradient_accumulation_boundary(False)
             if isinstance(

--- a/realhf/impl/model/backend/inference.py
+++ b/realhf/impl/model/backend/inference.py
@@ -18,7 +18,7 @@ from realhf.impl.model.nn.real_llm_generate import _gather_minibatch_gen_outputs
 logger = logging.getLogger("PipelinableInferenceEngine")
 
 
-class PipelinableInferenceEngine:
+class PipelinableInferenceEngine(model_api.PipelinableEngine):
 
     def __init__(self, module: ReaLModel):
         self.module = module
@@ -79,63 +79,27 @@ class PipelinableInferenceEngine:
         return self
 
     @torch.no_grad()
-    def eval_batch(
-        self,
-        input_: SequenceSample,
-        loss_fn: Callable,
-        num_micro_batches: Optional[int] = None,
-    ):
-        if constants.pipe_parallel_world_size() > 1:
-            if num_micro_batches is not None:
-                num_micro_batches = max(
-                    num_micro_batches, self.pipe_runner.default_inf_mbs
-                )
-            return self.pipe_runner.eval_batch(
-                input_=input_,
-                loss_fn=loss_fn,
-                num_micro_batches=num_micro_batches,
-            )
-        else:
-            if num_micro_batches is None:
-                num_micro_batches = 1
-            stat = collections.defaultdict(int)
-            for mb_input in input_.split(num_micro_batches):
-                input_lens = torch.tensor(
-                    flat2d(mb_input.seqlens["packed_input_ids"]),
-                    dtype=torch.int32,
-                    device="cuda",
-                )
-                max_seqlen = int(max(input_lens))
-                cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
-                model_output = self.module(
-                    packed_input_ids=mb_input.data["packed_input_ids"],
-                    cu_seqlens=cu_seqlens,
-                    max_seqlen=max_seqlen,
-                ).logits
-                _, _stat = loss_fn(model_output, mb_input)
-                for k, v in _stat.items():
-                    stat[k] += v
-            return stat
-
     def forward(
         self,
         input_: SequenceSample,
         num_micro_batches: Optional[int] = None,
+        post_hook: Callable[[torch.Tensor, SequenceSample], Any] | None = None,
+        aggregate_fn: Callable[[List[Any]], Any] = torch.cat,
     ):
-        if constants.pipe_parallel_world_size() > 1:
-            if num_micro_batches is not None:
-                num_micro_batches = max(
-                    num_micro_batches, self.pipe_runner.default_inf_mbs
+        # NOTE: Whether to interleave mini-batches in the pipeline results in
+        # similar inference time, but it may introduce a larger memory footprint,
+        # so we split mini-batches in the outer loop and call forward multiple times.
+
+        if num_micro_batches is None:
+            num_micro_batches = 1
+        outputs = []
+        for mb_input in input_.split(num_micro_batches):
+            if constants.pipe_parallel_world_size() > 1:
+                model_output = self.pipe_runner.forward(
+                    input_=input_,
+                    post_hook=post_hook,
                 )
-            return self.pipe_runner.forward(
-                input_=input_,
-                num_micro_batches=num_micro_batches,
-            )
-        else:
-            if num_micro_batches is None:
-                num_micro_batches = 1
-            outputs = []
-            for mb_input in input_.split(num_micro_batches):
+            else:
                 input_lens = torch.tensor(
                     flat2d(mb_input.seqlens["packed_input_ids"]),
                     dtype=torch.int32,
@@ -148,8 +112,10 @@ class PipelinableInferenceEngine:
                     cu_seqlens=cu_seqlens,
                     max_seqlen=max_seqlen,
                 ).logits
-                outputs.append(model_output)
-            return torch.cat(outputs, dim=0) if num_micro_batches > 1 else outputs[0]
+                if post_hook:
+                    model_output = post_hook(model_output, mb_input)
+            outputs.append(model_output)
+        return aggregate_fn(outputs) if num_micro_batches > 1 else outputs[0]
 
     @torch.no_grad()
     def generate(
@@ -161,22 +127,21 @@ class PipelinableInferenceEngine:
         ),
         num_micro_batches: Optional[int] = None,
     ):
-        if constants.pipe_parallel_world_size() > 1:
-            if num_micro_batches is not None:
-                num_micro_batches = max(
-                    num_micro_batches, self.pipe_runner.default_inf_mbs
+        # NOTE: Interleave mini-batches in the pipeline results will not decrease
+        # the memory usage, because we need to hold all KV-caches for different
+        # mini-batches, so we split mini-batches in the outer loop.
+
+        if num_micro_batches is None:
+            num_micro_batches = 1
+        sequences, scores, logits_mask = [], [], []
+        for mb_input in input_.split(num_micro_batches):
+            if constants.pipe_parallel_world_size() > 1:
+                seq, s, lmask = self.pipe_runner.generate(
+                    input_=input_,
+                    tokenizer=tokenizer,
+                    gconfig=gconfig,
                 )
-            return self.pipe_runner.generate(
-                input_=input_,
-                num_micro_batches=num_micro_batches,
-                tokenizer=tokenizer,
-                gconfig=gconfig,
-            )
-        else:
-            if num_micro_batches is None:
-                num_micro_batches = 1
-            sequences, scores, logits_mask = [], [], []
-            for mb_input in input_.split(num_micro_batches):
+            else:
                 input_lens = torch.tensor(
                     flat2d(mb_input.seqlens["packed_input_ids"]),
                     dtype=torch.int32,
@@ -191,13 +156,14 @@ class PipelinableInferenceEngine:
                     max_seqlen=max_seqlen,
                     gconfig=gconfig,
                 )
-                sequences.append(res.sequences)
-                scores.append(res.scores)
-                logits_mask.append(res.logits_mask)
-            if num_micro_batches == 1:
-                return sequences[0], scores[0], logits_mask[0]
-            else:
-                return _gather_minibatch_gen_outputs(sequences, scores, logits_mask)
+                seq, s, lmask = res.sequences, res.scores, res.logits_mask
+            sequences.append(seq)
+            scores.append(s)
+            logits_mask.append(lmask)
+        if num_micro_batches == 1:
+            return sequences[0], scores[0], logits_mask[0]
+        else:
+            return _gather_minibatch_gen_outputs(sequences, scores, logits_mask)
 
 
 @dataclasses.dataclass

--- a/realhf/impl/model/backend/inference.py
+++ b/realhf/impl/model/backend/inference.py
@@ -96,7 +96,7 @@ class PipelinableInferenceEngine(model_api.PipelinableEngine):
         for mb_input in input_.split(num_micro_batches):
             if constants.pipe_parallel_world_size() > 1:
                 model_output = self.pipe_runner.forward(
-                    input_=input_,
+                    input_=mb_input,
                     post_hook=post_hook,
                     aggregate_fn=aggregate_fn,
                 )
@@ -141,7 +141,7 @@ class PipelinableInferenceEngine(model_api.PipelinableEngine):
         for mb_input in input_.split(num_micro_batches):
             if constants.pipe_parallel_world_size() > 1:
                 res = self.pipe_runner.generate(
-                    input_=input_,
+                    input_=mb_input,
                     tokenizer=tokenizer,
                     gconfig=gconfig,
                 )

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -733,6 +733,7 @@ class ReaLMegatronEngine(model_api.PipelinableEngine):
         with megatron_ctx():
             self.engine.zero_grad()
             if constants.pipe_parallel_world_size() > 1:
+                # Fusing the minibatched forward-backward in a pipeline training schedule.
                 if num_micro_batches is not None:
                     if (
                         num_micro_batches < self.pipe_runner.default_train_mbs
@@ -754,7 +755,7 @@ class ReaLMegatronEngine(model_api.PipelinableEngine):
                     input_=input_,
                     loss_fn=loss_fn,
                     version_steps=version_steps,
-                    num_micro_batches=num_micro_batches,
+                    n_pp_mbs=num_micro_batches,
                 )
             else:
                 if num_micro_batches is None:

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -699,7 +699,7 @@ class PipeTrainInstrSetForMegatron(PipeTrainInstrSet):
         return update_successful, grad_norm, num_zeros_in_grad
 
 
-class ReaLMegatronEngine:
+class ReaLMegatronEngine(model_api.PipelinableEngine):
 
     def __init__(self, module: ReaLModel, megatron_engine: MegatronEngine):
         self.module = module
@@ -806,20 +806,16 @@ class ReaLMegatronEngine:
                 return stat
 
     @torch.no_grad()
-    def eval_batch(
-        self,
-        input_: SequenceSample,
-        loss_fn: Callable,
-        num_micro_batches: Optional[int] = None,
-    ):
-        return self.inf_engine.eval_batch(input_, loss_fn, num_micro_batches)
-
     def forward(
         self,
         input_: SequenceSample,
         num_micro_batches: Optional[int] = None,
+        post_hook: Callable[[torch.Tensor, SequenceSample], Any] | None = None,
+        aggregate_fn: Callable[[List[Any]], Any] = torch.cat,
     ):
-        return self.inf_engine.forward(input_, num_micro_batches)
+        return self.inf_engine.forward(
+            input_, num_micro_batches, post_hook=post_hook, aggregate_fn=aggregate_fn
+        )
 
     @torch.no_grad()
     def generate(
@@ -879,6 +875,7 @@ class MegatronTrainBackend(model_api.ModelBackend):
     efficient, either. We use Megatron because it is the only backend that we can
     make it functionally correct. The DeepSpeed code is too hard to read and modify.
     """
+
     optimizer_name: str = dataclasses.field(
         metadata={"choices": ["adam", "sgd"]},
         default="adam",

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -734,7 +734,10 @@ class ReaLMegatronEngine:
             self.engine.zero_grad()
             if constants.pipe_parallel_world_size() > 1:
                 if num_micro_batches is not None:
-                    if num_micro_batches < self.pipe_runner.default_train_mbs:
+                    if (
+                        num_micro_batches < self.pipe_runner.default_train_mbs
+                        and constants.parallelism_rank() == 0
+                    ):
                         logger.warning(
                             "When training with pipeline parallel, num micro batches should be "
                             "larger than 2 x num_pipeline_stages to avoid idle time. "
@@ -833,6 +836,49 @@ class ReaLMegatronEngine:
 
 @dataclasses.dataclass
 class MegatronTrainBackend(model_api.ModelBackend):
+    """When using the DistributedOptimizer of Megatron, parameters and
+    gradients will not be splitted across DP ranks, but optimizer states will
+    be. In other words, Megatron only supports ZeRO-1.
+
+    Megatron DDP will split the whole flattend parameter into buckets.
+    Buckets do not respect parameter boundaries and are dispatched to different DP ranks.
+    The optimizer on a specific DP rank will only manage its own bucket,
+    but parameters and gradients are held by all ranks and will not be further splitted.
+    (That's why only optimizer states are partitioned.) During backward, bucket gradients
+    will be scatter-reduced (controlled by the `use_distributed_optimizer` option
+    in Megatron DDP, otherwise all-reduce will be issued), and parameters will then
+    be updated locally. At this point, the parameters are not synced across DP ranks.
+    The DistributedOptimizer will then call all-gather on parameters.
+
+    Since Megatron allocates static tensors for scatter-reducing parameter gradients,
+    it does not decrease memory usage just as DeepSpeed ZeRO-2. To be more specific,
+    with dynamic allocation, we can allocate gradient memory layer-by-layer. When the
+    backward finishes at layer N, we can scatter-reduce gradients and release the memory
+    after scattering. As a result, given DP size K, layer number L, and parameter size P
+    for each layer, dynamic allocation requires P * (1 + L/K) memory for gradients,
+    but Megatron requires P * L. Memory is not freed after scattering in Megatron.
+
+    'use_distributed_optimizer' enables bucketing and scatter-reduce gradients.
+    When setting to False, optimizer states will not be partitioned.
+
+    'overlap_grad_reduce' enables issuing all-reduce/scatter-reduce on the fly
+    during bacwkard once the gradient is ready, which should usually be enabled.
+
+    'overlap_param_gather' overlaps param all-gather with the next forward pass.
+    It creates a forward hook that waits for the previous parameter all-gather
+    after the optimizer step. While this sounds good, it can be problematic with
+    parameter reallocation, because the reallocated parameters do not have the hook.
+    Can be enabled for SFT, but should be disabled for PPO.
+
+    As a final note, Megatron is in an awkward place for PPO with param-realloc.
+    First, it does not minimize the memory usage of gradients (i.e., ZeRO-2).
+    Second, for functional correctness, we can't enable `overlap_param_gather`,
+    and a parameter update will be scatter-reduce grad + all-gather param, instead
+    of an all-reduce (running all-reduce requires setting `use_distributed_optimizer`
+    to False, but that will not partition optimizer states!), so it is not that
+    efficient, either. We use Megatron because it is the only backend that we can
+    make it functionally correct. The DeepSpeed code is too hard to read and modify.
+    """
     optimizer_name: str = dataclasses.field(
         metadata={"choices": ["adam", "sgd"]},
         default="adam",
@@ -849,7 +895,7 @@ class MegatronTrainBackend(model_api.ModelBackend):
     enable_bf16: bool = False
     use_zero_optimization: bool = True
     overlap_grad_reduce: bool = True
-    overlap_param_gather: bool = True
+    overlap_param_gather: bool = False
     accumulate_allreduce_grads_in_fp32: bool = False
     initial_loss_scale: float = 4096.0
     gradient_clipping: float = 1.0

--- a/realhf/impl/model/backend/pipe_runner.py
+++ b/realhf/impl/model/backend/pipe_runner.py
@@ -42,7 +42,7 @@ def _split_and_prefill_pipe_input(
     tensor_buffer: TensorBuffer,
     num_micro_batches: int,
     store_kv_cache: bool,
-    loss_fn: Optional[Callable] = None,
+    store_input_cache: bool = False,
 ):
     """Prepare input for pipelined generate, train, or inference.
 
@@ -140,7 +140,7 @@ def _split_and_prefill_pipe_input(
         )
         tensor_buffer.put("pipe_transfer_infos", mbid, others_cache)
 
-    if loss_fn is not None:
+    if store_input_cache:
         for mbid, x1 in enumerate(splitted):
             tensor_buffer.put("input_cache", mbid, x1)
 
@@ -274,7 +274,7 @@ def _zero_grads(inputs):
 
 class PipeInferenceInstrSet:
 
-    def _exec_forward_pass(
+    def _fwd_impl(
         module: ReaLModel,
         tensor_buffer: TensorBuffer,
         stage_id: int,
@@ -303,9 +303,33 @@ class PipeInferenceInstrSet:
             "batch_output_x", micro_batch_id, x
         )  # Used by send_activation
 
+    def _exec_forward_pass(
+        module: ReaLModel,
+        tensor_buffer: TensorBuffer,
+        stage_id: int,
+        micro_batch_id: int,
+        step_id: int,
+    ):
+        PipeInferenceInstrSet._fwd_impl(
+            module, tensor_buffer, stage_id, micro_batch_id, step_id
+        )
+
+        x = tensor_buffer.get("batch_output_x", micro_batch_id, remove=False)
         if constants.is_last_pipe_stage():
             logits = x.pp_output
-            tensor_buffer.put("logits", micro_batch_id, logits)
+            post_hook = tensor_buffer.get(
+                "post_hook", micro_batch_id, raise_error=False
+            )
+            if constants.sequence_parallel():
+                pad_size = tensor_buffer.get("pad_size", micro_batch_id, remove=True)
+                logits = logits[:-pad_size] if pad_size > 0 else logits
+            if not post_hook:
+                tensor_buffer.put("output", micro_batch_id, logits)
+            else:
+                tensor_buffer.remove("batch_output_x", micro_batch_id)
+                input_ = tensor_buffer.get("input_cache", micro_batch_id)
+                output = post_hook(logits, input_)
+                tensor_buffer.put("output", micro_batch_id, output)
 
     def _exec_send_activations(
         module: ReaLModel,
@@ -632,7 +656,7 @@ class PipeTrainForwardCommInstrSet:
         micro_batch_id: int,
         step_id: int,
     ):
-        PipeInferenceInstrSet._exec_forward_pass(
+        PipeInferenceInstrSet._fwd_impl(
             module, tensor_buffer, stage_id, micro_batch_id, step_id
         )
 
@@ -769,18 +793,27 @@ class PipelineRunner:
     def train(self, *args, **kwargs):
         return self.module.train(*args, **kwargs)
 
+    @torch.no_grad()
     def forward(
         self,
         input_: SequenceSample,
         num_micro_batches: Optional[int] = None,
+        post_hook: Callable[[torch.Tensor, SequenceSample], Any] | None = None,
     ):
-        """Run one forward step over a batch of tokens and return the
-        logits."""
+        """Run one forward step over a batch of tokens and return the logits.
+
+        The method signature does not have "aggregate_fn" because the
+        pipeline model must output a torch.Tensor for each micro-batch.
+        Just use torch.cat.
+        """
 
         if num_micro_batches is None:
             num_micro_batches = self.default_inf_mbs
 
         tensor_buffer = TensorBuffer()
+        if post_hook is not None:
+            for i in range(num_micro_batches):
+                tensor_buffer.put("post_hook", i, post_hook)
 
         _split_and_prefill_pipe_input(
             module=self.module,
@@ -788,6 +821,7 @@ class PipelineRunner:
             num_micro_batches=num_micro_batches,
             input_=input_,
             store_kv_cache=False,
+            store_input_cache=post_hook is not None,
         )
 
         sched = schedule.InferenceSchedule(
@@ -802,18 +836,15 @@ class PipelineRunner:
             pipe_schedule=sched,
         )
 
-        logits = None
+        agg_output = None
         if constants.is_last_pipe_stage():
-            logits_list = []
+            output_list = []
             for i in range(num_micro_batches):
-                logits = tensor_buffer.get("logits", i, remove=True)
-                if constants.sequence_parallel():
-                    pad_size = tensor_buffer.get("pad_size", i, remove=True)
-                    logits = logits[:-pad_size] if pad_size > 0 else logits
-                logits_list.append(logits)
-            logits = torch.cat(logits_list, dim=0)
+                output = tensor_buffer.get("output", i, remove=True)
+                output_list.append(output)
+            agg_output = torch.cat(output_list, dim=0)
 
-        return logits
+        return agg_output
 
     @torch.no_grad()
     def generate(
@@ -948,7 +979,7 @@ class PipelineRunner:
             num_micro_batches=num_micro_batches,
             input_=input_,
             store_kv_cache=False,
-            loss_fn=loss_fn,
+            store_input_cache=True,
         )
 
         sched = schedule.TrainSchedule(
@@ -972,50 +1003,4 @@ class PipelineRunner:
             for key in stats[0].keys():
                 agg_stats[key] = torch.stack([stat[key] for stat in stats]).sum()
 
-        return agg_stats
-
-    @torch.no_grad()
-    def eval_batch(
-        self,
-        input_: SequenceSample,
-        loss_fn: Callable,
-        num_micro_batches: Optional[int] = None,
-    ):
-        if num_micro_batches is None:
-            num_micro_batches = self.default_train_mbs
-
-        tensor_buffer = TensorBuffer()
-        for i in range(num_micro_batches):
-            tensor_buffer.put("num_micro_batches", i, num_micro_batches)
-            tensor_buffer.put("loss_fn", i, loss_fn)
-
-        _split_and_prefill_pipe_input(
-            module=self.module,
-            tensor_buffer=tensor_buffer,
-            num_micro_batches=num_micro_batches,
-            input_=input_,
-            store_kv_cache=False,
-            loss_fn=loss_fn,
-        )
-
-        sched = schedule.InferenceSchedule(
-            micro_batches=num_micro_batches,
-            stages=constants.pipe_parallel_world_size(),
-            stage_id=constants.pipe_parallel_rank(),
-        )
-        _exec_pipe_schedule(
-            module=self.module,
-            tensor_buffer=tensor_buffer,
-            instr_map=PipeTrainForwardCommInstrSet.INSTRUCTION_MAP,
-            pipe_schedule=sched,
-        )
-
-        agg_stats = None
-        if constants.is_last_pipe_stage():
-            stats = []
-            for mbid in range(num_micro_batches):
-                stats.append(tensor_buffer.get("stats", mbid))
-            agg_stats = dict()
-            for key in stats[0].keys():
-                agg_stats[key] = torch.stack([stat[key] for stat in stats]).sum()
         return agg_stats

--- a/realhf/impl/model/interface/dpo_interface.py
+++ b/realhf/impl/model/interface/dpo_interface.py
@@ -110,17 +110,28 @@ class DPOInterface(model_api.ModelInterface):
         module = model.module
         module.eval()
 
-        logits = module.forward(input_=input_, num_micro_batches=n_mbs)
-        if logits is None:
+        input_lens = torch.tensor(input_.seqlens["packed_input_ids"]).view(-1)
+        cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
+
+        # This post_hook will gather log probabilities in mini-batches,
+        # reducing peak memory usage.
+        def calc_logprobs(logits, input_):
+            logprobs = gather_packed_shifted_log_probs(
+                logits, cu_seqlens, input_.data["packed_input_ids"]
+            )
+            return logprobs
+
+        logprobs = module.forward(
+            input_=input_,
+            num_micro_batches=n_mbs,
+            post_hook=calc_logprobs,
+        )
+
+        if logprobs is None:
             return None
 
-        input_lens = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
-        cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
         prompt_lens = input_.data["prompt_lens"]
-
-        logprobs = gather_packed_shifted_log_probs(
-            logits, cu_seqlens, input_.data["packed_input_ids"]
-        ).float()
+        logprobs = logprobs.float()
 
         assert (prompt_lens > 0).all(), prompt_lens
         logprob_sum = []

--- a/realhf/impl/model/interface/dpo_interface.py
+++ b/realhf/impl/model/interface/dpo_interface.py
@@ -110,7 +110,7 @@ class DPOInterface(model_api.ModelInterface):
         module = model.module
         module.eval()
 
-        input_lens = torch.tensor(input_.seqlens["packed_input_ids"]).view(-1)
+        input_lens = torch.tensor(flat2d(input_.seqlens["packed_input_ids"]))
         cu_seqlens = torch.nn.functional.pad(input_lens.cumsum(0), (1, 0)).int()
 
         # This post_hook will gather log probabilities in mini-batches,

--- a/realhf/impl/model/interface/gen_interface.py
+++ b/realhf/impl/model/interface/gen_interface.py
@@ -1,4 +1,7 @@
 import dataclasses
+import fcntl
+import json
+import os
 
 import colorama
 import torch
@@ -6,12 +9,35 @@ import torch
 import realhf.api.core.model_api as model_api
 from realhf.api.core.data_api import SequenceSample
 from realhf.base import constants, logging
+from realhf.base.datapack import flat2d
 
 logger = logging.getLogger("Generation Interface", "benchmark")
 
 
+def acquire_lock(lock_file):
+    fd = open(lock_file, "w")
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
+
+
+def release_lock(lock_fd):
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    lock_fd.close()
+
+
+def write_dict_to_jsonl(dict_data, file_path, lock_file):
+    lock_fd = acquire_lock(lock_file)
+    try:
+        with open(file_path, "a") as file:
+            json.dump(dict_data, file)
+            file.write("\n")
+    finally:
+        release_lock(lock_fd)
+
+
 @dataclasses.dataclass
 class GenerationInterface(model_api.ModelInterface):
+    output_file: str | None = None
     generation_config: model_api.GenerationHyperparameters = dataclasses.field(
         default_factory=model_api.GenerationHyperparameters
     )
@@ -44,27 +70,101 @@ class GenerationInterface(model_api.ModelInterface):
         if res is None:
             return None
 
-        gen_tokens, logprobs, *_ = res
+        gen_tokens, *_ = res
 
-        # Decode and log the first generated sentence.
-        l = input_.seqlens["packed_prompts"][0][0]
-        tokens = torch.cat(
-            [input_.data["packed_prompts"][:l], gen_tokens[0]]
-        ).unsqueeze(0)
-        out = model.tokenizer.batch_decode(
-            tokens, skip_special_tokens=True, clean_up_tokenization_spaces=True
-        )
-        if constants.model_parallel_rank() == 0 and constants.is_last_pipe_stage():
+        res = {
+            "generated_length": gen_tokens.shape[1],
+            "batch_size": gen_tokens.shape[0],
+        }
+        if not (
+            constants.model_parallel_rank() == 0 and constants.is_last_pipe_stage()
+        ):
+            # Not DP head, return stats.
+            return res
+
+        if self.output_file is not None:
+
+            # Concatenate prompts with gen_tokens, decode, and output to file.
+            prompt_lens = flat2d(input_.seqlens["packed_prompts"])
+            gen_lengths = (gen_tokens != model.tokenizer.pad_token_id).logical_and(
+                gen_tokens != model.tokenizer.eos_token_id
+            ).sum(dim=-1) + 1
+            gen_lengths = gen_lengths.clip(max=gen_tokens.shape[-1])
+            assert len(gen_lengths) == len(prompt_lens) == input_.bs, (
+                input_.bs,
+                len(prompt_lens),
+                len(gen_lengths),
+            )
+
+            prompt_tokens_lis = []
+            ans_tokens_lis = []
+            prompt_offset = 0
+            for i, (prompt_len, gen_len) in enumerate(zip(prompt_lens, gen_lengths)):
+                prompt_tokens_lis.append(
+                    input_.data["packed_prompts"][
+                        prompt_offset : prompt_offset + prompt_len
+                    ]
+                )
+                ans_tokens_lis.append(gen_tokens[i, :gen_len])
+                prompt_offset += prompt_len
+            assert prompt_offset == sum(prompt_lens)
+            seq_tokens_lis = [
+                torch.cat([a, b]) for a, b in zip(prompt_tokens_lis, ans_tokens_lis)
+            ]
+
+            prompt_str = model.tokenizer.batch_decode(
+                prompt_tokens_lis,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=True,
+            )
+            ans_str = model.tokenizer.batch_decode(
+                ans_tokens_lis,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=True,
+            )
+            seq_str = model.tokenizer.batch_decode(
+                seq_tokens_lis,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=True,
+            )
+
+            lock_file = os.path.join(
+                constants.LOG_ROOT,
+                constants.experiment_name(),
+                constants.trial_name(),
+                "_gen.lock",
+            )
+            output_file = os.path.join(
+                constants.LOG_ROOT,
+                constants.experiment_name(),
+                constants.trial_name(),
+                self.output_file,
+            )
+            if constants.data_parallel_rank() == 0:
+                logger.info(f"Dumping output to: {output_file}...")
+            for p, a, s, _id in zip(prompt_str, ans_str, seq_str, input_.ids):
+                d = dict(
+                    prompt=p,
+                    answer=a,
+                    seq=s,
+                    id=_id,
+                )
+                write_dict_to_jsonl(d, output_file, lock_file)
+        else:
+            # Decode and log the first generated sentence.
+            l = input_.seqlens["packed_prompts"][0][0]
+            tokens = torch.cat(
+                [input_.data["packed_prompts"][:l], gen_tokens[0]]
+            ).unsqueeze(0)
+            out = model.tokenizer.batch_decode(
+                tokens, skip_special_tokens=True, clean_up_tokenization_spaces=True
+            )
             dp_rank = constants.data_parallel_rank()
             logger.info(
                 f"DP rank {dp_rank}, the first generated sequence "
                 f"is: {colorama.Fore.YELLOW + colorama.Style.DIM}{out[0]}{colorama.Style.RESET_ALL}"
             )
 
-        res = {
-            "generated_length": gen_tokens.shape[1],
-            "batch_size": gen_tokens.shape[0],
-        }
         return res
 
 

--- a/realhf/impl/model/interface/ppo_interface.py
+++ b/realhf/impl/model/interface/ppo_interface.py
@@ -204,7 +204,7 @@ class PPOActorInterface(model_api.ModelInterface):
         if res is None:
             return None
 
-        gen_tokens, logprobs, logits_mask, *_ = res
+        gen_tokens, logprobs, logits_mask = res
 
         pad_token_id = model.tokenizer.pad_token_id
         eos_token_id = model.tokenizer.eos_token_id

--- a/realhf/impl/model/interface/rw_interface.py
+++ b/realhf/impl/model/interface/rw_interface.py
@@ -229,12 +229,13 @@ class PairedRewardInterface(model_api.ModelInterface):
 
         for step, data in enumerate(tqdm.tqdm(eval_dataloader)):
             data: SequenceSample
-            stats = model.eval_batch(
+            res = model.eval_batch(
                 input_=data.cuda(),
                 loss_fn=_paired_rw_loss_from_model_outputs,
             )
 
-            if stats:
+            if res is not None:
+                _, stats = res
                 losses += stats["loss"].item()
                 correct_predictions += stats["correct_predictions"].item()
                 total_predictions += stats["total_predictions"].item()

--- a/realhf/impl/model/nn/real_llm_generate.py
+++ b/realhf/impl/model/nn/real_llm_generate.py
@@ -392,6 +392,7 @@ def _gather_minibatch_gen_outputs(
     all_gen_tokens: List[torch.LongTensor],
     all_log_probs: List[torch.FloatTensor],
     all_logits_mask: List[torch.BoolTensor],
+    pad_token_id: int,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Concate over the batch dimension given multiple [bs, seqlen] mini-batch
     tensors.
@@ -417,7 +418,9 @@ def _gather_minibatch_gen_outputs(
 
         if gen_len < max_gen_tokens_length:
             pad_size = max_gen_tokens_length - gen_len
-            gen_token = torch.nn.functional.pad(gen_token, (0, pad_size))
+            gen_token = torch.nn.functional.pad(
+                gen_token, (0, pad_size), value=pad_token_id
+            )
             log_probs = torch.nn.functional.pad(log_probs, (0, pad_size))
             if logits_mask is not None:
                 logits_mask = torch.nn.functional.pad(

--- a/realhf/impl/model/parallelism/pipeline_parallel/static_schedule.py
+++ b/realhf/impl/model/parallelism/pipeline_parallel/static_schedule.py
@@ -206,9 +206,7 @@ class GenerateSchedule(PipeSchedule):
         self.next_stage = self.next_stage % self.stages
         self.max_new_tokens = max_new_tokens
         self.max_steps = (
-            max_new_tokens * max(self.n_pp_mbs, self.stages)
-            + self.n_pp_mbs
-            - 1
+            max_new_tokens * max(self.n_pp_mbs, self.stages) + self.n_pp_mbs - 1
         )  # a configurable upper bound
 
     def _valid_token_id(self, token_id):
@@ -233,9 +231,7 @@ class GenerateSchedule(PipeSchedule):
                 else -1
             )
             # the micro_batch_id of the last stage on last step
-            token_id = (step_id - self.stage_id) // max(
-                self.n_pp_mbs, self.stages
-            )
+            token_id = (step_id - self.stage_id) // max(self.n_pp_mbs, self.stages)
             # token id in current round
 
             # TODO: from last stage to first stage, need one buffer for each microbatch?

--- a/realhf/impl/model/parallelism/pipeline_parallel/static_schedule.py
+++ b/realhf/impl/model/parallelism/pipeline_parallel/static_schedule.py
@@ -111,7 +111,7 @@ class PipeSchedule(ABC):
         return self.stages
 
     @property
-    def num_micro_batches(self):
+    def n_pp_mbs(self):
         """The number of total micro_batches used to configure this
         schedule."""
         return self.micro_batches
@@ -206,8 +206,8 @@ class GenerateSchedule(PipeSchedule):
         self.next_stage = self.next_stage % self.stages
         self.max_new_tokens = max_new_tokens
         self.max_steps = (
-            max_new_tokens * max(self.num_micro_batches, self.stages)
-            + self.num_micro_batches
+            max_new_tokens * max(self.n_pp_mbs, self.stages)
+            + self.n_pp_mbs
             - 1
         )  # a configurable upper bound
 
@@ -220,21 +220,21 @@ class GenerateSchedule(PipeSchedule):
         for step_id in range(self.max_steps):
             cmds = []
             micro_batch_id = (
-                (step_id - self.stage_id) % max(self.num_micro_batches, self.stages)
+                (step_id - self.stage_id) % max(self.n_pp_mbs, self.stages)
                 if step_id - self.stage_id >= 0
                 else -1
             )  # micro batch id for current stage
             first_round = (
-                step_id < self.num_micro_batches
+                step_id < self.n_pp_mbs
             )  # whether it is the first round of generate
             last_stage_last_mbid = (
-                (step_id - self.stages) % max(self.num_micro_batches, self.stages)
+                (step_id - self.stages) % max(self.n_pp_mbs, self.stages)
                 if step_id >= self.stages
                 else -1
             )
             # the micro_batch_id of the last stage on last step
             token_id = (step_id - self.stage_id) // max(
-                self.num_micro_batches, self.stages
+                self.n_pp_mbs, self.stages
             )
             # token id in current round
 
@@ -312,13 +312,12 @@ class GenerateSchedule(PipeSchedule):
 
     def num_pipe_buffers(self):
         """2 buffers for inter stage transfer (except last stage to first
-        stage) self.num_micro_batches buffers for last stage to first stage
-        transfer.
+        stage) self.n_pp_mbs buffers for last stage to first stage transfer.
 
         Returns:
-            ``2 + self.num_micro_batches``
+            ``2 + self.n_pp_mbs``
         """
-        return 2  # + self.num_micro_batches
+        return 2  # + self.n_pp_mbs
 
 
 class TrainSchedule(PipeSchedule):

--- a/realhf/system/master_worker.py
+++ b/realhf/system/master_worker.py
@@ -1344,6 +1344,12 @@ class MasterWorker(worker_base.Worker):
 
         if is_new_epoch:
             if self._epoch > self.__total_train_epochs:
+                if should_eval or should_save:
+                    logger.info(
+                        f"Waiting for all save/eval requests at the last step"
+                        f" for {self.config.exp_ctrl.save_eval_timeout} secs..."
+                    )
+                    time.sleep(self.config.exp_ctrl.save_eval_timeout)
                 self.experiment_complete_exit(f"Training completes! Yeah!!!")
 
         total_time_consumption = time.perf_counter() - self._train_start_time

--- a/realhf/system/master_worker.py
+++ b/realhf/system/master_worker.py
@@ -551,7 +551,7 @@ async def model_rpc_request_func(
             assert sample.bs % dp_size == 0
             min_n_seqs_per_dp = sample.bs // dp_size
         else:
-            min_n_seqs_per_dp = 1
+            min_n_seqs_per_dp = rpc.n_mbs
         split_spec = sample.get_split_spec(dp_size, min_size=min_n_seqs_per_dp)
         partitions = split_spec.partitions
         target_mapping = {i: list(range(v[0], v[1])) for i, v in enumerate(partitions)}

--- a/realhf/system/master_worker.py
+++ b/realhf/system/master_worker.py
@@ -551,7 +551,7 @@ async def model_rpc_request_func(
             assert sample.bs % dp_size == 0
             min_n_seqs_per_dp = sample.bs // dp_size
         else:
-            min_n_seqs_per_dp = rpc.n_mbs
+            min_n_seqs_per_dp = rpc.n_mbs if rpc.n_mbs is not None else 1
         split_spec = sample.get_split_spec(dp_size, min_size=min_n_seqs_per_dp)
         partitions = split_spec.partitions
         target_mapping = {i: list(range(v[0], v[1])) for i, v in enumerate(partitions)}


### PR DESCRIPTION


# Patch Fixes:

+ Raise an error when using parameter reallocaiton with the DS backend.

+ Set `use_cuda_graph=True` in all example scripts and remove the error message in PPO/GRPO/Reinforce experiments when using CUDAGraph.

+ Backend API change: 
    + Add a `post_hook` argument in the forward (aka inference) API, which is a function that does post-processing on the output logits, e.g., collecting log probabilities from the logits. This is useful with mini-batched inference since it doesn't need to save all model outputs and can save a large amount of GPU memory.

    + Unify the forward and eval_batch APIs. eval_batch is now a special case of forward with a post_hook collecting losses and statistics.

    + For inference and generate calls, the mini-batches are splitted in the outer loop. We call `engine.generate` or `engine.inference` multiple times, which will have similar end-to-end latency but save GPU memory. For example, KV-cache and intermediate activations are not kept for all mini-batches at a time.

+ In the `load_hf_tokenizer` function, set `trust_remote_code=True` be default.

+ Automatically amend IDs for datasets.

# Bug Fixes:

+ The `overlap_param_gather` option in the Megatron backend now defaults to False rather than True. PPO w. parameter reallocation can be algorithmically incorrect when enabling this option. See explanations in `realhf/impl/model/backend/megatron.py`.

+ Fix the padding value when gathering mini-batched generation outputs. If the padding value is not `pad_token_id`, the generation length calculated by the PPO interface will be incorrect.

+ Restrict the model saving handlers to be all trainable models, otherwise the request can be sent to models that are not instantiated yet (e.g., the actor used for generation with parameter reallocation).

+ Fix all examples to make them runnable.

+ The minimum batch size per DP rank should be `n_mbs` instead of 1 in the master worker.

+ Request evaluation and model saving outside coroutines when the experiment is abort to complete. This fixes the bug that the model at the last epoch will not be saved.

+ Resolve the issues of the generation interface mentioned in #59 .

----

# Changes after review

+ Add a mini-batched PPO script example.

+ Fix the bug of pipeline mini-batched inference/generate.

+ Distinguish the named used for minibatch for pipelining and interfaces.


