### PR TITLE
[New Feature] Add utilities for profiling individual interfaces.

### DIFF
--- a/examples/new_algorithms/reinforce/reinforce_exp.py
+++ b/examples/new_algorithms/reinforce/reinforce_exp.py
@@ -2,6 +2,8 @@ import copy
 import dataclasses
 from typing import *
 
+from omegaconf import OmegaConf
+
 import realhf.api.core.model_api as model_api
 import realhf.base.logging as logging
 from examples.new_algorithms.reinforce.reinforce_interface import ReinforceInterface
@@ -64,7 +66,11 @@ class ReinforceConfig(CommonExperimentConfig):
         actor_sample_interface = ModelInterfaceAbstraction(
             "reinforce",
             args=dict(
-                generation_config=self.gen,
+                # NOTE: to_container converts the object to a dict
+                # It is used for unifying the profiling API, which requires to
+                # pass external interface configurations in the launch command.
+                # Customized dataclass objects will not work in that case.
+                generation_config=OmegaConf.to_container(self.gen, resolve=True),
                 discount=self.discount,
                 adv_norm=self.adv_norm,
             ),

--- a/examples/new_algorithms/reinforce/reinforce_interface.py
+++ b/examples/new_algorithms/reinforce/reinforce_interface.py
@@ -66,12 +66,13 @@ def _reinforce_loss_from_model_outputs(
 class ReinforceInterface(model_api.ModelInterface):
 
     force_greedy: bool = False
-    generation_config: model_api.GenerationHyperparameters = dataclasses.field(
-        default_factory=model_api.GenerationHyperparameters
-    )
+    generation_config: Dict = dataclasses.field(default_factory=dict)
     enable_save: bool = True
     discount: float = 0.99
     adv_norm: bool = True
+
+    def __post_init__(self):
+        self.gconfig = model_api.GenerationHyperparameters(**self.generation_config)
 
     def save(self, model: model_api.Model, save_dir: str):
         # NOTE: import here to avoid cuda initialization
@@ -103,11 +104,11 @@ class ReinforceInterface(model_api.ModelInterface):
 
         module.eval()
 
-        self.generation_config.greedy = self.force_greedy
+        self.gconfig.greedy = self.force_greedy
         res = module.generate(
             input_=input_,
             tokenizer=model.tokenizer,
-            gconfig=self.generation_config,
+            gconfig=self.gconfig,
             num_micro_batches=n_mbs,
         )
         if res is None:

--- a/examples/profiling/allocations.jsonl
+++ b/examples/profiling/allocations.jsonl
@@ -1,0 +1,1 @@
+{"data_parallel_size": 2, "model_parallel_size": 4, "pipeline_parallel_size": 1, "use_sequence_parallel": true}

--- a/examples/profiling/datasets.jsonl
+++ b/examples/profiling/datasets.jsonl
@@ -1,0 +1,1 @@
+{"type_": "prompt", "args": {"max_length": 1024, "pad_to_max_length": true, "dataset_path": "/lustre/fw/datasets/imdb/rl/ppo_prompt.jsonl"}}

--- a/examples/profiling/interfaces.jsonl
+++ b/examples/profiling/interfaces.jsonl
@@ -1,0 +1,1 @@
+{"type_": "ppo_actor", "args": {"generation_config": {"max_new_tokens": 1024,"min_new_tokens": 1024,"use_cuda_graph": true,"force_no_logits_mask": true,"force_cudagraph_recapture": true,"top_p": 1.0,"top_k": 1000000},"enable_save": false,"n_minibatches": 8}}

--- a/examples/profiling/models.jsonl
+++ b/examples/profiling/models.jsonl
@@ -1,0 +1,1 @@
+{"type": {"_class": "llama"}, "path": "/lustre/public/pretrained_model_weights/Llama-2-7b-hf"}

--- a/examples/profiling/profile.sh
+++ b/examples/profiling/profile.sh
@@ -1,0 +1,48 @@
+# The model to profile and its path.
+MODEL_FAMILY=llama
+SFT_MODEL_PATH=/lustre/public/pretrained_model_weights/Llama-2-7b-hf
+
+EXP_NAME=profile-example
+TRIAL_NAME=test
+
+export CLUSTER_SPEC_PATH="/lustre/aigc/llm/cluster/qh.json"
+
+# Setting REAL_DUMP_TRACE=1 enables execution trace provided by PyTorch.
+
+# Setting REAL_DUMP_MEMORY=1 enables memory profiling provided by PyTorch.
+
+# The dataset content doesn't matter, as long as it is a prompt-only dataset.
+# Each entry in the dataset should contain two keys "id" and "prompt".
+# By default we pad the prompt to the maximum length in the batch for accurate system-wise benchmark.
+# The loaded data will be processed by the "_mock_${handle_name}" method in the interface
+# to create mock data suited for the exact interface handle.
+
+# "handle_name" can be "inference", "generate", or "train_step",
+# and the "interface_impl" specifies which registered interface implementation to run.
+# "interface_kwargs_json" is a JSON configuration of the interface.
+
+# "allocations_jsonl" is a JSONL file that specifies the parallel strategies to profile.
+# If not specified, all parallel strategies under the given world size will be profiled.
+
+# "n_mbs" specifies the number of micro-batches to profile.
+
+# The total number of runs will be the product of the number of micro-batches and the number of parallel strategies,
+# all within the same experiment_name and trial_name. Instead of re-launching the whole experiment, workers will
+# be paused and reconfigured to run the next experiment setup.
+
+REAL_DUMP_TRACE=1 REAL_DUMP_MEMORY=1 \
+    python3 -m realhf.apps.quickstart profile \
+    mode=local \
+    experiment_name=$EXP_NAME \
+    trial_name=$TRIAL_NAME \
+    exp_ctrl.benchmark_steps=3 \
+    exp_ctrl.save_freq_steps=null \
+    exp_ctrl.eval_freq_steps=null \
+    n_nodes=1 \
+    'handle_names=[train_step]' \
+    interfaces_jsonl=./examples/profiling/interfaces.jsonl \
+    models_jsonl=./examples/profiling/models.jsonl \
+    datasets_jsonl=./examples/profiling/datasets.jsonl \
+    allocations_jsonl=./examples/profiling/allocations.jsonl \
+    'n_mbs=[1, 2, 4]' \
+    'batch_sizes=[512]'

--- a/realhf/api/core/data_api.py
+++ b/realhf/api/core/data_api.py
@@ -596,7 +596,7 @@ class DataBatchMeta:
 @dataclasses.dataclass
 class DatasetUtility:
     seed: int
-    ddp_rank: int
+    dp_rank: int
     world_size: int
     tokenizer: transformers.PreTrainedTokenizerFast
 
@@ -648,7 +648,7 @@ def load_shuffle_split_dataset(
         util.seed, datasize_per_rank * util.world_size
     )
     subset_indices = shuffle_indices[
-        util.ddp_rank * datasize_per_rank : (util.ddp_rank + 1) * datasize_per_rank
+        util.dp_rank * datasize_per_rank : (util.dp_rank + 1) * datasize_per_rank
     ]
     data: List[Dict[str, str]] = [data[i] for i in subset_indices]
 
@@ -667,7 +667,7 @@ def register_dataset(name, dataset_cls):
 def make_dataset(
     cfg: Union[str, config_api.DatasetAbstraction],
     seed: int,
-    ddp_rank: int,
+    dp_rank: int,
     world_size: int,
     tokenizer_or_tokenizer_name: Union[transformers.PreTrainedTokenizerFast, str],
     experiment_name: str,
@@ -685,7 +685,7 @@ def make_dataset(
         tokenizer = tokenizer_or_tokenizer_name
     util = DatasetUtility(
         seed,
-        ddp_rank,
+        dp_rank,
         world_size,
         tokenizer,
     )
@@ -711,7 +711,7 @@ def make_dataset(
         cfg.type_,
         f"seed{seed}",
         f"world_size{world_size}",
-        f"rank{ddp_rank}",
+        f"rank{dp_rank}",
     )
     os.makedirs(output_path, exist_ok=True)
 
@@ -720,11 +720,11 @@ def make_dataset(
 
     tik = time.perf_counter()
     if not cache_found:
-        logger.info(f"No data cache found for rank {ddp_rank}. Create it from scratch.")
-        dataset = ALL_DATASET_CLASSES[cfg.type_](seed, ddp_rank, world_size, **cfg.args)
+        logger.info(f"No data cache found for rank {dp_rank}. Create it from scratch.")
+        dataset = ALL_DATASET_CLASSES[cfg.type_](seed, dp_rank, world_size, **cfg.args)
         torch.save(dataset, os.path.join(output_path, fname))
     else:
-        logger.info(f"Rank {ddp_rank} find existing data cache, load it.")
+        logger.info(f"Rank {dp_rank} find existing data cache, load it.")
         dataset = torch.load(os.path.join(output_path, fname))
     logger.info(f"Dataset creation/loading time: {time.perf_counter() - tik:.3f}s")
 

--- a/realhf/api/core/model_api.py
+++ b/realhf/api/core/model_api.py
@@ -358,6 +358,9 @@ class ModelBackend(abc.ABC):
         model.ft_spec = spec
         return self._initialize(model, spec)
 
+    def destroy(self, model: Model):
+        pass
+
 
 class NullBackend(ModelBackend):
 
@@ -403,6 +406,31 @@ class ModelInterface(abc.ABC):
         self, model: Model, data: SequenceSample, n_mbs: Optional[int] = None
     ) -> Dict:
         raise NotImplementedError()
+
+    # Mock methods for creating data and profiling an individual MFC.
+    def _mock_generate(self, model: Model, data: SequenceSample):
+        return data
+
+    def _mock_inference(self, model: Model, data: SequenceSample):
+        return data
+
+    def _mock_train_step(self, model: Model, data: SequenceSample):
+        return data
+
+    def mock(
+        self,
+        type_: str,
+        model: Model,
+        data: SequenceSample,
+    ) -> SequenceSample:
+        if type_ == "generate":
+            return self._mock_generate(model, data)
+        elif type_ == "inference":
+            return self._mock_inference(model, data)
+        elif type_ == "train_step":
+            return self._mock_train_step(model, data)
+        else:
+            raise ValueError(f"Unsupported interface type {type_}")
 
 
 ALL_MODEL_CLASSES = {}

--- a/realhf/api/core/system_api.py
+++ b/realhf/api/core/system_api.py
@@ -141,6 +141,8 @@ class ModelWorker:
     msid2mwid: Dict[ModelShardID, int] = None
     data_transfer_pairs: List[Tuple[str, str]] = None
     sync_param_pairs: List[Tuple[str, str]] = None
+    # profiling
+    profile_mode: bool = False
     worker_info: Optional[WorkerInformation] = None
 
     def __post_init__(self):
@@ -237,7 +239,6 @@ class ExperimentConfig:
     model_worker: List[ModelWorker] = dataclasses.field(default_factory=list)
     # master_worker will be set automatically
     master_worker: Optional[List[MasterWorker]] = None
-    config: Optional[Any] = None
 
     def __post_init__(self):
         assert self.master_worker is None
@@ -512,67 +513,14 @@ class ExperimentConfig:
 class Experiment:
     """Base class for defining the procedure of an experiment."""
 
-    def scheduling_setup(self, config) -> ExperimentScheduling:
+    def scheduling_setup(self) -> ExperimentScheduling:
         """Returns the Scheduling of all workers."""
         raise NotImplementedError()
 
-    def initial_setup(self, config) -> ExperimentConfig:
+    def initial_setup(self) -> ExperimentConfig | List[ExperimentConfig]:
         """Returns a list of workers to create when a trial of the experiment
         is initialized."""
         raise NotImplementedError()
-
-
-def dump_config_to_yaml(config, file):
-    import yaml
-
-    with open(file, "w") as f:
-        yaml.dump(dataclass_to_dict(config), f)
-
-
-def load_config_from_yaml(file):
-    import yaml
-
-    with open(file, "r") as f:
-        return config_to_dataclass(yaml.safe_load(f))
-
-
-def dataclass_to_dict(dc):
-    if isinstance(dc, (str, int, float)) or dc is None:
-        pass
-    elif isinstance(dc, enum.Enum):
-        dc = dc.value
-    elif isinstance(dc, (list, tuple)):
-        dc = [dataclass_to_dict(d) for d in dc]
-    elif isinstance(dc, dict):
-        dc = {k: dataclass_to_dict(v) for k, v in dc.items()}
-    elif dataclasses.is_dataclass(dc):
-        root_name = dc.__class__.__name__
-        dc = dict(
-            config_class=root_name,
-            config_value={
-                k.name: dataclass_to_dict(getattr(dc, k.name))
-                for k in dataclasses.fields(dc)
-            },
-        )
-    else:
-        raise f"{dc} of type {type(dc)} cannot be parse to dict."
-    return dc
-
-
-def config_to_dataclass(config: Union[List, Dict]):
-    if isinstance(config, (list, tuple)):
-        return [config_to_dataclass(c) for c in config]
-    elif isinstance(config, dict):
-        if "config_class" in config.keys():
-            return getattr(sys.modules[__name__], config["config_class"])(
-                **{k: config_to_dataclass(v) for k, v in config["config_value"].items()}
-            )
-        else:
-            return config
-    elif isinstance(config, (str, int, float)) or config is None:
-        return config
-    else:
-        raise NotImplementedError(config)
 
 
 ALL_EXPERIMENT_CLASSES = {}

--- a/realhf/apps/main.py
+++ b/realhf/apps/main.py
@@ -117,6 +117,8 @@ def main_start(args, recover_count: int = 0):
         CLUSTER_SPEC_PATH=cluster_spec_path,
         REAL_RECOVER_RUN="1" if is_recover_run else "0",
         REAL_SAVE_RECOVER_STATES="1" if save_recover_states else "0",
+        REAL_DUMP_TRACE=os.environ.get("REAL_DUMP_TRACE", "0"),
+        REAL_DUMP_MEMORY=os.environ.get("REAL_DUMP_MEMORY", "0"),
     )
     for k, v in BASE_ENVIRONS.items():
         os.environ[k] = v
@@ -284,10 +286,17 @@ def _main_profile_layers(model_family, model_path):
     )
 
     if check_slurm_availability():
+        if not os.environ.get("CLUSTER_SPEC_PATH", ""):
+            raise ValueError(
+                "Environment variable CLUSTER_SPEC_PATH must be set for slurm mode! "
+                "See example/cluster_config.json for a template."
+            )
         BASE_ENVIRONS = constants.get_env_vars(
             WANDB_MODE="disabled",
             REAL_MODE="slurm",
             CLUSTER_SPEC_PATH=os.environ.get("CLUSTER_SPEC_PATH", ""),
+            REAL_DUMP_TRACE=os.environ.get("REAL_DUMP_TRACE", "0"),
+            REAL_DUMP_MEMORY=os.environ.get("REAL_DUMP_MEMORY", "0"),
         )
         clear_name_resolve(expr_name, trial_name)
         sched = sched_client.make(

--- a/realhf/apps/quickstart.py
+++ b/realhf/apps/quickstart.py
@@ -16,6 +16,7 @@ import_module(
     str(pathlib.Path(__file__).resolve().parent.parent / "experiments" / "common"),
     re.compile(r".*_exp\.py$"),
 )
+import realhf.experiments.benchmark.profile_exp
 
 
 def main():

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -76,7 +76,6 @@ TORCH_EXTENSIONS_DIR = (
 QUICKSTART_EXPR_CACHE_PATH = f"{cluster_spec.fileroot}/.cache/{getpass.getuser()}/"
 BASE_ENVIRONS = {
     "PYTHONPATH": "/realhf",
-    "REAL_TRACE": os.getenv("REAL_TRACE", "0"),
     "REAL_IS_REMOTE": "1",
     # "NCCL_P2P_DISABLE": "1",
     # "NCCL_IB_DISABLE": "1",
@@ -107,7 +106,9 @@ BASE_ENVIRONS = {
     # https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573
     "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
     # Whether to enable time mark to plot timelines.
-    # "REAL_CUDA_TMARK": "1",
+    "REAL_CUDA_TMARK": os.getenv("REAL_CUDA_TMARK", "0"),
+    "REAL_DUMP_TRACE": os.getenv("REAL_DUMP_TRACE", "0"),
+    "REAL_DUMP_MEMORY": os.getenv("REAL_DUMP_MEMORY", "0"),
 }
 
 

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -142,7 +142,27 @@ _global_memory_buffer: GlobalMemoryBuffer = GlobalMemoryBuffer()
 _fake_mp_world_size = None
 _fake_mp_rank = None
 
+# GLOBAL_STATS_TRACKER is used to track and log training stats that cannot be gracefully obtained via model outputs
+# in interface implementations, e.g. load balancing loss in each MoE layer.
+GLOBAL_STATS_TRACKER = defaultdict(dict)
+GLOBAL_STATS_TRACKER_LOG_HOOKS = defaultdict(dict)
+
 # TODO: As in Megatron, we can set NCCL group options. Is it necessary?
+
+
+def reset_run():
+    global _model_name, _grids, _pgroups, _pgroup_ranks, _self_group, _rank_mapping, _global_memory_buffer, _fake_mp_world_size, _fake_mp_rank, GLOBAL_STATS_TRACKER, GLOBAL_STATS_TRACKER_LOG_HOOKS
+    _model_name = None
+    _grids = {}
+    _pgroups = {}
+    _pgroup_ranks = {}
+    _self_group = None
+    _rank_mapping = {}
+    _global_memory_buffer = GlobalMemoryBuffer()
+    _fake_mp_world_size = None
+    _fake_mp_rank = None
+    GLOBAL_STATS_TRACKER = defaultdict(dict)
+    GLOBAL_STATS_TRACKER_LOG_HOOKS = defaultdict(dict)
 
 
 @contextlib.contextmanager
@@ -453,10 +473,6 @@ def get_env_vars(**kwargs):
 
 
 ################# logging related #################
-# GLOBAL_STATS_TRACKER is used to track and log training stats that cannot be gracefully obtained via model outputs
-# in interface implementations, e.g. load balancing loss in each MoE layer.
-GLOBAL_STATS_TRACKER = defaultdict(dict)
-GLOBAL_STATS_TRACKER_LOG_HOOKS = defaultdict(dict)
 
 
 def save_to_global_stats_tracker(

--- a/realhf/base/gpu_utils.py
+++ b/realhf/base/gpu_utils.py
@@ -54,7 +54,7 @@ def set_cuda_device(device):
         torch.cuda.set_device(device)
 
 
-def reveal_ddp_identity(expr_name, trial_name, worker_index):
+def reveal_pg_identity(expr_name, trial_name, worker_index):
     master_group_name = names.distributed_peer(
         expr_name, trial_name, GLOBAL_PROCESS_GROUP_NAME
     )
@@ -75,8 +75,6 @@ def isolate_cuda_device(
     For example, if a job has 2 jobsteps, each with 1 GPU, and is allocated onto GPU 0 and 1,
     then CUDA_VISIBLE_DEVICES of these jobsteps will be 0,1, instead of 0 and 1.
     We use this function in `apps.remote` to isolate CUDA_VISIBLE_DEVICES for each jobstep.
-
-    Note that this function is completely independent of `setup_ddp`.
 
     Args:
         worker_type (str): .

--- a/realhf/base/gpu_utils.py
+++ b/realhf/base/gpu_utils.py
@@ -55,12 +55,10 @@ def set_cuda_device(device):
 
 
 def reveal_ddp_identity(expr_name, trial_name, worker_index):
-    master_group_name = names.trainer_ddp_peer(
+    master_group_name = names.distributed_peer(
         expr_name, trial_name, GLOBAL_PROCESS_GROUP_NAME
     )
     name_resolve.add_subentry(master_group_name, str(worker_index), keepalive_ttl=30)
-    # local_peer_name = names.trainer_ddp_local_peer(expr_name, trial_name, socket.gethostname(), peer_name)
-    # name_resolve.add_subentry(local_peer_name, peer_index, keepalive_ttl=30)
 
 
 def isolate_cuda_device(
@@ -93,7 +91,7 @@ def isolate_cuda_device(
 
     name_resolve_identifier = f"__type_{worker_type}"
     name_resolve.add_subentry(
-        names.trainer_ddp_local_peer(
+        names.distributed_local_peer(
             experiment_name,
             trial_name,
             socket.gethostname(),
@@ -103,7 +101,7 @@ def isolate_cuda_device(
         keepalive_ttl=60,
     )
     name_resolve.add_subentry(
-        names.trainer_ddp_peer(experiment_name, trial_name, name_resolve_identifier),
+        names.distributed_peer(experiment_name, trial_name, name_resolve_identifier),
         rank,
         keepalive_ttl=30,
     )
@@ -113,7 +111,7 @@ def isolate_cuda_device(
     while (
         len(
             name_resolve.get_subtree(
-                names.trainer_ddp_peer(
+                names.distributed_peer(
                     experiment_name, trial_name, name_resolve_identifier
                 )
             )
@@ -122,7 +120,7 @@ def isolate_cuda_device(
     ):
         time.sleep(0.1)
     # logger.info(f"Rank {rank} discovers all peers, resolving local rank...")
-    local_peer_name = names.trainer_ddp_local_peer(
+    local_peer_name = names.distributed_local_peer(
         experiment_name,
         trial_name,
         socket.gethostname(),

--- a/realhf/base/names.py
+++ b/realhf/base/names.py
@@ -28,67 +28,31 @@ def worker(experiment_name, trial_name, worker_name):
     return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/worker/{worker_name}"
 
 
-def worker2(experiment_name, trial_name, worker_type, worker_index):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/worker/{worker_type}/{worker_index}"
-
-
-def inference_stream(experiment_name, trial_name, stream_name):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/inference_stream/{stream_name}"
-
-
-def inference_stream_constant(experiment_name, trial_name, stream_name, constant_name):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/inference_stream_consts/{stream_name}/{constant_name}"
-
-
-def sample_stream(experiment_name, trial_name, stream_name):
-    return (
-        f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/sample_stream/{stream_name}"
-    )
+def worker_key(experiment_name, trial_name, key):
+    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/worker_key/{key}"
 
 
 def request_reply_stream(experiment_name, trial_name, stream_name):
     return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/request_reply_stream/{stream_name}"
 
 
-def trainer_ddp_peer(experiment_name, trial_name, model_name):
+def request_reply_stream_root(experiment_name, trial_name):
+    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/request_reply_stream/"
+
+
+def distributed_root(experiment_name, trial_name):
+    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/distributed/"
+
+
+def distributed_peer(experiment_name, trial_name, model_name):
     return (
-        f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/trainer_ddp_peer/{model_name}"
+        f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/distributed/peer/{model_name}"
     )
 
 
-def trainer_ddp_local_peer(experiment_name, trial_name, host_name, model_name):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/trainer_ddp_local_peer/{host_name}/{model_name}"
+def distributed_local_peer(experiment_name, trial_name, host_name, model_name):
+    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/distributed/local_peer/{host_name}/{model_name}"
 
 
-def trainer_ddp_master(experiment_name, trial_name, model_name):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/trainer_ddp_master/{model_name}"
-
-
-def worker_key(experiment_name, trial_name, key):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/worker_key/{key}"
-
-
-def parameter_subscription(experiment_name, trial_name):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/parameter_sub"
-
-
-def parameter_server(experiment_name, trial_name, parameter_id_str):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/parameter_server/{parameter_id_str}"
-
-
-def shared_memory(experiment_name, trial_name, stream_name):
-    return (
-        f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/shared_memory/{stream_name}"
-    )
-
-
-def shared_memory_dock_server(experiment_name, trial_name, stream_name, server_type):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/shared_memory_dock_server/{server_type}/{stream_name}"
-
-
-def model_controller(experiment_name, trial_name, model_name, dp_rank, mp_rank):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/model_controller/{model_name}/{dp_rank}/{mp_rank}"
-
-
-def model_controller_barrier(experiment_name, trial_name, model_name, dp_rank, mp_rank):
-    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/model_controller_barrier/{model_name}/{dp_rank}/{mp_rank}"
+def distributed_master(experiment_name, trial_name, model_name):
+    return f"{USER_NAMESPACE}/{experiment_name}/{trial_name}/distributed/master/{model_name}"

--- a/realhf/base/testing.py
+++ b/realhf/base/testing.py
@@ -79,7 +79,7 @@ class StandaloneTestingProcess(mp.Process):
         self.barrier.wait()
 
         # init process group
-        gpu_utils.reveal_ddp_identity(self.expr_name, self.trial_name, self.rank)
+        gpu_utils.reveal_pg_identity(self.expr_name, self.trial_name, self.rank)
         self.barrier.wait()
         from realhf.impl.model.comm.global_comm import setup_global_comm
 

--- a/realhf/base/topology.py
+++ b/realhf/base/topology.py
@@ -36,6 +36,17 @@ def destroy_all_comm_groups():
     dist.destroy_process_group()
 
 
+def decompose_to_three_factors(n: int) -> List[Tuple[int, int, int]]:
+    factors = []
+    for i in range(1, int(n ** (1 / 2)) + 1):
+        if n % i == 0:
+            for j in range(i, int((n // i) ** (1 / 2)) + 1):
+                if (n // i) % j == 0:
+                    k = (n // i) // j
+                    factors += list(set(itertools.permutations([i, j, k])))
+    return factors
+
+
 class ProcessCoord(NamedTuple):
     pipe: int
     data: int

--- a/realhf/base/topology.py
+++ b/realhf/base/topology.py
@@ -26,6 +26,16 @@ def new_or_get_group(ranks: List[int], backend=None):
     return GLOBAL_PROCESS_GROUP_REGISTRY[key]
 
 
+def destroy_all_comm_groups():
+    if not dist.is_initialized():
+        return
+    global GLOBAL_PROCESS_GROUP_REGISTRY
+    for group in GLOBAL_PROCESS_GROUP_REGISTRY.values():
+        dist.destroy_process_group(group)
+    GLOBAL_PROCESS_GROUP_REGISTRY = {}
+    dist.destroy_process_group()
+
+
 class ProcessCoord(NamedTuple):
     pipe: int
     data: int

--- a/realhf/experiments/benchmark/profile_exp.py
+++ b/realhf/experiments/benchmark/profile_exp.py
@@ -19,20 +19,10 @@ from realhf.api.quickstart.device_mesh import MFCConfig
 from realhf.api.quickstart.entrypoint import register_quickstart_exp
 from realhf.api.quickstart.model import ModelTrainEvalConfig, ParallelismConfig
 from realhf.base import constants, logging
+from realhf.base.topology import decompose_to_three_factors
 from realhf.experiments.common.common import CommonExperimentConfig
 
 logger = logging.getLogger("Profiling Experiment", "system")
-
-
-def decompose_to_three_factors(n: int) -> List[Tuple[int, int, int]]:
-    factors = []
-    for i in range(1, int(n ** (1 / 2)) + 1):
-        if n % i == 0:
-            for j in range(i, int((n // i) ** (1 / 2)) + 1):
-                if (n // i) % j == 0:
-                    k = (n // i) // j
-                    factors += list(set(itertools.permutations([i, j, k])))
-    return factors
 
 
 def default_parallel_config(n_gpus: int) -> List[Dict[str, Any]]:

--- a/realhf/experiments/benchmark/profile_exp.py
+++ b/realhf/experiments/benchmark/profile_exp.py
@@ -1,0 +1,264 @@
+import copy
+import dataclasses
+import itertools
+import json
+import os
+from typing import *
+
+from omegaconf import OmegaConf
+
+from realhf.api.core.config import (
+    DatasetAbstraction,
+    ModelInterfaceAbstraction,
+    ModelInterfaceType,
+)
+from realhf.api.core.dfg import MFCDef
+from realhf.api.core.system_api import ExperimentConfig
+from realhf.api.quickstart.dataset import PromptOnlyDatasetConfig
+from realhf.api.quickstart.device_mesh import MFCConfig
+from realhf.api.quickstart.entrypoint import register_quickstart_exp
+from realhf.api.quickstart.model import ModelTrainEvalConfig, ParallelismConfig
+from realhf.base import constants, logging
+from realhf.experiments.common.common import CommonExperimentConfig
+
+logger = logging.getLogger("Profiling Experiment", "system")
+
+
+def decompose_to_three_factors(n: int) -> List[Tuple[int, int, int]]:
+    factors = []
+    for i in range(1, int(n ** (1 / 2)) + 1):
+        if n % i == 0:
+            for j in range(i, int((n // i) ** (1 / 2)) + 1):
+                if (n // i) % j == 0:
+                    k = (n // i) // j
+                    factors += list(set(itertools.permutations([i, j, k])))
+    return factors
+
+
+def default_parallel_config(n_gpus: int) -> List[Dict[str, Any]]:
+    factors = decompose_to_three_factors(n_gpus)
+    x = [
+        {
+            "data_parallel_size": dp,
+            "model_parallel_size": mp,
+            "pipeline_parallel_size": pp,
+            "use_sequence_parallel": mp > 1,
+        }
+        for dp, mp, pp in factors
+    ]
+    x += [
+        {
+            "data_parallel_size": dp,
+            "model_parallel_size": mp,
+            "pipeline_parallel_size": pp,
+            "use_sequence_parallel": False,
+        }
+        for dp, mp, pp in factors
+        if mp > 1
+    ]
+    return x
+
+
+def dataclass_from_dict(klass, d):
+    try:
+        fieldtypes = {f.name: f.type for f in dataclasses.fields(klass)}
+        return klass(**{f: dataclass_from_dict(fieldtypes[f], d[f]) for f in d})
+    except:
+        return d  # Not a dataclass field
+
+
+@dataclasses.dataclass
+class ProfileConfig(CommonExperimentConfig):
+    """The experiment configuration for profiling layers and interfaces.
+
+    The `initial_setup` method in this experiment will return a list of
+    experiment configurations, which will be run sequentially.
+    All configurations share the same experiment name, trial name,
+    and the scheduling configuration. They can have different models,
+    datasets, or parallel strategies, as long as they always occupy
+    a fixed number of GPUs.
+
+    It's important to note that, if any error occurs during the execution,
+    the experiment will terminate immediately. In particular, the OOM error
+    should not appear because the profiling setup usually uses a small model.
+    """
+
+    interfaces_jsonl: str = ""
+    allocations_jsonl: Optional[str] = None
+    handle_names: Optional[List[str]] = None
+    n_mbs: Optional[List[int]] = None
+    batch_sizes: Optional[List[int]] = None
+    models_jsonl: str = ""
+    datasets_jsonl: str = ""
+
+    def __post_init__(self):
+        # Check that handle_name belones to ["train_step", "generate", "inference"]
+        self.handle_names = list(set(self.handle_names))
+        if any(
+            k not in ["train_step", "generate", "inference"] for k in self.handle_names
+        ):
+            raise NotImplementedError(f"Unknown handle_name: {self.handle_name}")
+
+        # Check the configuration of interfaces
+        if not os.path.exists(self.interfaces_jsonl):
+            raise FileNotFoundError(
+                f"File not found: {self.interfaces_jsonl}. "
+                "It should be a JSONL file specifying the arguments "
+                "for the interface implementation."
+            )
+        with open(self.interfaces_jsonl, "r") as f:
+            self.interface_kwargs = [json.loads(l) for l in f.readlines()]
+
+        # Check the configuration of parallel strategies.
+        if self.allocations_jsonl is None:
+            self.parallel_kwargs = default_parallel_config(
+                self.n_nodes * self.n_gpus_per_node
+            )
+        else:
+            assert self.allocations_jsonl.endswith(".jsonl")
+            assert os.path.exists(self.allocations_jsonl)
+            with open(self.allocations_jsonl, "r") as f:
+                self.parallel_kwargs = [json.loads(l) for l in f.readlines()]
+        for pcfg in self.parallel_kwargs:
+            assert isinstance(pcfg, dict), type(pcfg)
+            assert all(
+                k
+                in [
+                    "data_parallel_size",
+                    "model_parallel_size",
+                    "pipeline_parallel_size",
+                    "use_sequence_parallel",
+                ]
+                for k in pcfg.keys()
+            ), pcfg.keys()
+            assert (self.n_nodes * self.n_gpus_per_node) == (
+                pcfg.get("data_parallel_size", 1)
+                * pcfg.get("model_parallel_size", 1)
+                * pcfg.get("pipeline_parallel_size", 1)
+            )
+
+        if self.n_mbs is None:
+            self.n_mbs = [1]
+        else:
+            self.n_mbs = OmegaConf.to_container(self.n_mbs)
+            assert isinstance(self.n_mbs, list), type(self.n_mbs)
+            assert all(isinstance(x, int) for x in self.n_mbs)
+
+        assert self.batch_sizes is not None
+
+        assert os.path.exists(self.models_jsonl)
+        with open(self.models_jsonl, "r") as f:
+            self.model_kwargs = [json.loads(l) for l in f.readlines()]
+
+        assert os.path.exists(self.datasets_jsonl)
+        with open(self.datasets_jsonl, "r") as f:
+            self.dataset_kwargs = [json.loads(l) for l in f.readlines()]
+            assert all(x["type_"] == "prompt" for x in self.dataset_kwargs)
+
+    @property
+    def allocations(self):
+        return dict(default=self._tmp_allocation)
+
+    @property
+    def models(self):
+        return dict(default=self._tmp_model)
+
+    @property
+    def tokenizer_name_or_path(self):
+        return self._tmp_model.path
+
+    @property
+    def max_prompt_len(self):
+        return self._tmp_dataset.args["max_length"]
+
+    @property
+    def datasets(self):
+        return [self._tmp_dataset]
+
+    @property
+    def rpcs(self):
+        return dict(default=self._tmp_rpc)
+
+    def initial_setup(self) -> List[ExperimentConfig]:
+        self.allocation_mode = "manual"
+        setups = []
+        setup_log_path = os.path.join(
+            constants.LOG_ROOT,
+            self.experiment_name,
+            self.trial_name,
+            "setups.jsonl",
+        )
+        logger.info(
+            f"Experiment setup configurations of the profiling experiment "
+            f"will be saved to: {setup_log_path}"
+        )
+        with open(setup_log_path, "w") as f:
+            # batch size in the most outer loop to delay the possible OOM error
+            for (
+                bs,
+                pcfg,
+                n_mbs,
+                model_cfg,
+                dataset_cfg,
+                handle_name,
+                interface_cfg,
+            ) in itertools.product(
+                self.batch_sizes,
+                self.parallel_kwargs,
+                self.n_mbs,
+                self.model_kwargs,
+                self.dataset_kwargs,
+                self.handle_names,
+                self.interface_kwargs,
+            ):
+                if handle_name == "generate" and pcfg["use_sequence_parallel"]:
+                    continue
+
+                kwargs_stat = dict(
+                    parallel=pcfg,
+                    n_mbs=n_mbs,
+                    model=model_cfg,
+                    dataset=dataset_cfg,
+                    interface=interface_cfg,
+                    bs=bs,
+                )
+                f.write(json.dumps(kwargs_stat) + "\n")
+
+                # Create tmp object for constructing experiment setups
+                self._tmp_allocation = MFCConfig(
+                    parallel=ParallelismConfig(**pcfg), n_mbs=n_mbs
+                )
+                self._tmp_model = dataclass_from_dict(ModelTrainEvalConfig, model_cfg)
+                self._tmp_dataset = DatasetAbstraction(**dataset_cfg)
+                if handle_name == "train_step":
+                    interface_type = ModelInterfaceType.TRAIN_STEP
+                elif handle_name == "inference":
+                    interface_type = ModelInterfaceType.INFERENCE
+                elif handle_name == "generate":
+                    interface_type = ModelInterfaceType.GENERATE
+                else:
+                    raise NotImplementedError(
+                        f"Unknown which handle to run in the interface: {self.handle_name}"
+                    )
+                self._tmp_rpc = MFCDef(
+                    n_seqs=bs,
+                    name="default",
+                    n_mbs=n_mbs,
+                    interface_type=interface_type,
+                    interface_impl=ModelInterfaceAbstraction(**interface_cfg),
+                    model_name="default",
+                    input_keys=["packed_prompts"],
+                    log_return_value=False,
+                    model_type=self._tmp_model.type,
+                    model_path=self._tmp_model.path,
+                    balanced_dp=True,
+                )
+
+                setup = copy.deepcopy(super().initial_setup())
+                for m in setup.model_worker:
+                    m.profile_mode = True
+                setups.append(setup)
+        return setups
+
+
+register_quickstart_exp("profile", ProfileConfig)

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -3,6 +3,7 @@ import dataclasses
 import functools
 import itertools
 import pprint
+import re
 from collections import defaultdict
 from typing import *
 
@@ -323,6 +324,7 @@ class CommonExperimentConfig(Experiment):
 
         self.__check_legal_allocation_options()
 
+        para3d_pattern = r"d(\d+)p(\d+)m(\d+)"
         rpcs = self.rpcs
         if self.allocation_mode == "search":
             # assert self.mode == "slurm"

--- a/realhf/experiments/common/gen_exp.py
+++ b/realhf/experiments/common/gen_exp.py
@@ -53,7 +53,7 @@ class GenerationConfig(CommonExperimentConfig):
 
         util = DatasetUtility(
             seed=0,
-            ddp_rank=0,
+            dp_rank=0,
             world_size=1,
             tokenizer=load_hf_tokenizer(self.model.path),
         )

--- a/realhf/experiments/common/gen_exp.py
+++ b/realhf/experiments/common/gen_exp.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from omegaconf import OmegaConf
+
 from realhf.api.core.config import (
     DatasetAbstraction,
     ModelInterfaceAbstraction,
@@ -81,9 +83,16 @@ class GenerationConfig(CommonExperimentConfig):
 
     @property
     def rpcs(self):
+        # NOTE: to_container converts the object to a dict
+        # It is used for unifying the profiling API, which requires to
+        # pass external interface configurations in the launch command.
+        # Customized dataclass objects will not work in that case.
         interface = ModelInterfaceAbstraction(
             "generation",
-            args={"generation_config": self.gen, "output_file": self.output_file},
+            args={
+                "generation_config": OmegaConf.to_container(self.gen, resolve=True),
+                "output_file": self.output_file,
+            },
         )
         gen = MFCDef(
             name="gen",

--- a/realhf/experiments/common/ppo_exp.py
+++ b/realhf/experiments/common/ppo_exp.py
@@ -4,6 +4,7 @@ import math
 from typing import *
 
 import numpy as np
+from omegaconf import OmegaConf
 
 import realhf.base.logging as logging
 from realhf.api.core.config import (
@@ -251,7 +252,11 @@ class PPOConfig(CommonExperimentConfig):
             "ppo_actor",
             args={
                 **copy.deepcopy(self.ppo_kwargs),
-                "generation_config": self.ppo.gen,
+                # NOTE: to_container converts the object to a dict
+                # It is used for unifying the profiling API, which requires to
+                # pass external interface configurations in the launch command.
+                # Customized dataclass objects will not work in that case.
+                "generation_config": OmegaConf.to_container(self.ppo.gen, resolve=True),
                 "early_stop_imp_ratio": self.ppo.early_stop_imp_ratio,
                 "adv_norm": self.ppo.adv_norm,
             },

--- a/realhf/impl/model/backend/megatron.py
+++ b/realhf/impl/model/backend/megatron.py
@@ -993,5 +993,15 @@ class MegatronTrainBackend(model_api.ModelBackend):
         model.module = ReaLMegatronEngine(real_model, mg_engine)
         return model
 
+    def destroy(self, model: model_api.Model):
+        assert isinstance(model.module, ReaLMegatronEngine)
+        optimizer = model.module.engine.optim
+        # The Megatron backend will register forward hooks that
+        # create circular references (grad -> param -> grad).
+        # Deleting models directly will not release the memory.
+        # We must disable hooks at first.
+        if self.use_zero_optimization and self.overlap_param_gather:
+            optimizer.disable_pre_hook()
+
 
 model_api.register_backend("megatron", MegatronTrainBackend)

--- a/realhf/impl/model/comm/global_comm.py
+++ b/realhf/impl/model/comm/global_comm.py
@@ -54,7 +54,7 @@ def setup_global_comm(
             map(
                 int,
                 name_resolve.get_subtree(
-                    names.trainer_ddp_peer(
+                    names.distributed_peer(
                         expr_name,
                         trial_name,
                         gpu_utils.GLOBAL_PROCESS_GROUP_NAME,
@@ -90,7 +90,7 @@ def setup_global_comm(
     else:
         local_gpu_id = global_rank
 
-    ddp_master_name = names.trainer_ddp_master(
+    ddp_master_name = names.distributed_master(
         expr_name, trial_name, gpu_utils.GLOBAL_PROCESS_GROUP_NAME
     )
 

--- a/realhf/impl/model/comm/global_comm.py
+++ b/realhf/impl/model/comm/global_comm.py
@@ -90,27 +90,27 @@ def setup_global_comm(
     else:
         local_gpu_id = global_rank
 
-    ddp_master_name = names.distributed_master(
+    pg_master_name = names.distributed_master(
         expr_name, trial_name, gpu_utils.GLOBAL_PROCESS_GROUP_NAME
     )
 
     if worker_index == 0:
         host_ip = socket.gethostbyname(socket.gethostname())
         port = network.find_free_port()
-        ddp_init_address = f"tcp://{host_ip}:{port}"
-        name_resolve.add(ddp_master_name, ddp_init_address, keepalive_ttl=300)
+        pg_init_addr = f"tcp://{host_ip}:{port}"
+        name_resolve.add(pg_master_name, pg_init_addr, keepalive_ttl=300)
     else:
         try:
-            ddp_init_address = name_resolve.wait(ddp_master_name, timeout=300)
+            pg_init_addr = name_resolve.wait(pg_master_name, timeout=300)
         except TimeoutError:
             raise TimeoutError(
-                f"global_rank={global_rank} worker_index={worker_index} wait for ddp_init_method timeout."
+                f"global_rank={global_rank} worker_index={worker_index} wait for process group init timeout."
             )
 
     torch_dist_kwargs = dict(
         world_size=world_size,
         rank=global_rank,
-        init_method=ddp_init_address,
+        init_method=pg_init_addr,
         backend=backend,
         timeout=constants.NCCL_DEFAULT_TIMEOUT,
     )

--- a/realhf/impl/model/interface/gen_interface.py
+++ b/realhf/impl/model/interface/gen_interface.py
@@ -38,9 +38,10 @@ def write_dict_to_jsonl(dict_data, file_path, lock_file):
 @dataclasses.dataclass
 class GenerationInterface(model_api.ModelInterface):
     output_file: str | None = None
-    generation_config: model_api.GenerationHyperparameters = dataclasses.field(
-        default_factory=model_api.GenerationHyperparameters
-    )
+    generation_config: dict = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        self.gconfig = model_api.GenerationHyperparameters(**self.generation_config)
 
     @torch.no_grad()
     def generate(
@@ -64,7 +65,7 @@ class GenerationInterface(model_api.ModelInterface):
         res = module.generate(
             input_=x,
             tokenizer=model.tokenizer,
-            gconfig=self.generation_config,
+            gconfig=self.gconfig,
             num_micro_batches=n_mbs,
         )
         if res is None:

--- a/realhf/impl/model/interface/ppo_interface.py
+++ b/realhf/impl/model/interface/ppo_interface.py
@@ -110,9 +110,8 @@ def _ppo_actor_loss_from_model_outputs(
 class PPOActorInterface(model_api.ModelInterface):
     n_minibatches: int = 4
 
-    generation_config: model_api.GenerationHyperparameters = dataclasses.field(
-        default_factory=model_api.GenerationHyperparameters
-    )
+    # Use dict here to allow argument passing through commandline.
+    generation_config: Dict = dataclasses.field(default_factory=dict)
 
     kl_ctl: float = 0.1
 
@@ -165,6 +164,8 @@ class PPOActorInterface(model_api.ModelInterface):
                 raise ValueError(f"Unknown value_norm_type {self.value_norm_type}")
         self.kl_ctl = None
 
+        self.gconfig = model_api.GenerationHyperparameters(**self.generation_config)
+
     def save(self, model: model_api.Model, save_dir: str):
         if not self.enable_save:
             return
@@ -198,7 +199,7 @@ class PPOActorInterface(model_api.ModelInterface):
         res = module.generate(
             input_=x,
             tokenizer=model.tokenizer,
-            gconfig=self.generation_config,
+            gconfig=self.gconfig,
             num_micro_batches=n_mbs,
         )
         if res is None:
@@ -235,21 +236,18 @@ class PPOActorInterface(model_api.ModelInterface):
         )
 
         seqlens = [[s] for s in seq_lengths.cpu().numpy().tolist()]
+        data = dict(
+            seq_no_eos_mask=seq_no_eos_mask,
+            packed_input_ids=packed_input_ids,
+            packed_logprobs=packed_logprobs,
+            prompt_mask=prompt_mask,
+        )
+        if not self.gconfig.force_no_logits_mask:
+            data["packed_logits_mask"] = packed_logits_mask.bool()
         res = SequenceSample.from_default(
             ids=input_.ids,
             seqlens=seqlens,
-            data=dict(
-                seq_no_eos_mask=seq_no_eos_mask,
-                packed_input_ids=packed_input_ids,
-                packed_logprobs=packed_logprobs,
-                packed_logits_mask=(
-                    packed_logits_mask.bool()
-                    if not self.generation_config.force_no_logits_mask
-                    and packed_logits_mask is not None
-                    else None
-                ),
-                prompt_mask=prompt_mask,
-            ),
+            data=data,
         )
         return res
 
@@ -266,7 +264,7 @@ class PPOActorInterface(model_api.ModelInterface):
         # This post_hook will gather log probabilities in mini-batches,
         # reducing peak memory usage.
         def calc_logprobs(logits, input_):
-            logits /= self.generation_config.temperature
+            logits /= self.gconfig.temperature
             if (
                 "packed_logits_mask" in input_.data
                 and input_.data["packed_logits_mask"] is not None
@@ -478,6 +476,86 @@ class PPOActorInterface(model_api.ModelInterface):
 
         return dict(train_stats)
 
+    # Mock methods for profiling only.
+    def _mock_inference(
+        self,
+        model: model_api.Model,
+        dataset_input: SequenceSample,
+    ) -> SequenceSample:
+        prompt_lens = flat2d(dataset_input.seqlens["packed_prompts"])
+        seqlens = [x + self.gconfig.max_new_tokens for x in prompt_lens]
+        module = model.module
+        if not isinstance(module, ReaLModel):
+            module = module.module
+        mconfig = module.config
+        packed_input_ids = torch.randint(
+            0,
+            mconfig.vocab_size,
+            (sum(seqlens),),
+            dtype=torch.long,
+            device=model.device,
+        )
+
+        return SequenceSample.from_default(
+            seqlens=seqlens,
+            ids=dataset_input.ids,
+            data=dict(packed_input_ids=packed_input_ids),
+        )
+
+    # Mock methods for profiling only.
+    def _mock_train_step(
+        self,
+        model: model_api.Model,
+        dataset_input: SequenceSample,
+    ) -> Dict:
+        prompt_lens = flat2d(dataset_input.seqlens["packed_prompts"])
+        bs = len(prompt_lens)
+        seqlens = [x + self.gconfig.max_new_tokens for x in prompt_lens]
+        module = model.module
+        if not isinstance(module, ReaLModel):
+            module = module.module
+        mconfig = module.config
+        mdtype = module.dtype
+        short1_seqlens = [x - 1 for x in seqlens]
+
+        packed_logprobs = torch.randn(
+            (sum(short1_seqlens),), dtype=mdtype, device=model.device
+        )
+        packed_ref_logprobs = torch.randn_like(packed_logprobs)
+        prompt_mask = torch.zeros(
+            (sum(seqlens),), dtype=torch.bool, device=model.device
+        )
+        packed_input_ids = torch.randint(
+            0,
+            mconfig.vocab_size,
+            (sum(seqlens),),
+            dtype=torch.long,
+            device=model.device,
+        )
+        rewards = torch.randn(bs, dtype=mdtype, device=model.device)
+        seq_no_eos_mask = torch.randint(
+            0, 2, (bs,), dtype=torch.bool, device=model.device
+        )
+        values = torch.randn(
+            (sum(seqlens),),
+            dtype=mdtype,
+            device=model.device,
+        )
+
+        return SequenceSample.from_default(
+            seqlens=seqlens,
+            ids=dataset_input.ids,
+            data=dict(
+                packed_logprobs=packed_logprobs,
+                packed_ref_logprobs=packed_ref_logprobs,
+                prompt_mask=prompt_mask,
+                packed_input_ids=packed_input_ids,
+                rewards=rewards,
+                seq_no_eos_mask=seq_no_eos_mask,
+                values=values,
+            ),
+        )
+
 
 def _ppo_critic_loss_from_model_outputs(
     new_values: torch.FloatTensor,
@@ -613,6 +691,7 @@ class PPOCriticInterface(model_api.ModelInterface):
         input_: SequenceSample,
         n_mbs=None,
     ) -> SequenceSample:
+        assert model.module.module.config.is_critic
         module = model.module
         module.eval()
 
@@ -630,6 +709,7 @@ class PPOCriticInterface(model_api.ModelInterface):
     def train_step(
         self, model: model_api.Model, input_: SequenceSample, n_mbs=None
     ) -> Dict:
+        assert model.module.module.config.is_critic
         module = model.module
         tokenizer = model.tokenizer
         # We call module.eval() because dropout causes the computation of incorrect of log probs.
@@ -771,6 +851,84 @@ class PPOCriticInterface(model_api.ModelInterface):
             )
 
         return dict(train_stats)
+
+    # Mock methods for profiling only.
+    def _mock_inference(
+        self,
+        model: model_api.Model,
+        dataset_input: SequenceSample,
+    ) -> SequenceSample:
+        seqlens = flat2d(dataset_input.seqlens["packed_prompts"])
+        module = model.module
+        if not isinstance(module, ReaLModel):
+            module = module.module
+        mconfig = module.config
+        packed_input_ids = torch.randint(
+            0,
+            mconfig.vocab_size,
+            (sum(seqlens),),
+            dtype=torch.long,
+            device=model.device,
+        )
+
+        return SequenceSample.from_default(
+            seqlens=seqlens,
+            ids=dataset_input.ids,
+            data=dict(packed_input_ids=packed_input_ids),
+        )
+
+    # Mock methods for profiling only.
+    def _mock_train_step(
+        self,
+        model: model_api.Model,
+        dataset_input: SequenceSample,
+    ) -> Dict:
+        seqlens = flat2d(dataset_input.seqlens["packed_prompts"])
+        bs = len(seqlens)
+        module = model.module
+        if not isinstance(module, ReaLModel):
+            module = module.module
+        mconfig = module.config
+        mdtype = module.dtype
+        short1_seqlens = [x - 1 for x in seqlens]
+
+        packed_logprobs = torch.randn(
+            (sum(short1_seqlens),), dtype=mdtype, device=model.device
+        )
+        packed_ref_logprobs = torch.randn_like(packed_logprobs)
+        prompt_mask = torch.zeros(
+            (sum(seqlens),), dtype=torch.bool, device=model.device
+        )
+        packed_input_ids = torch.randint(
+            0,
+            mconfig.vocab_size,
+            (sum(seqlens),),
+            dtype=torch.long,
+            device=model.device,
+        )
+        rewards = torch.randn(bs, dtype=mdtype, device=model.device)
+        seq_no_eos_mask = torch.randint(
+            0, 2, (bs,), dtype=torch.bool, device=model.device
+        )
+        values = torch.randn(
+            (sum(seqlens),),
+            dtype=mdtype,
+            device=model.device,
+        )
+
+        return SequenceSample.from_default(
+            seqlens=seqlens,
+            ids=dataset_input.ids,
+            data=dict(
+                packed_logprobs=packed_logprobs,
+                packed_ref_logprobs=packed_ref_logprobs,
+                prompt_mask=prompt_mask,
+                packed_input_ids=packed_input_ids,
+                rewards=rewards,
+                seq_no_eos_mask=seq_no_eos_mask,
+                values=values,
+            ),
+        )
 
 
 model_api.register_interface("ppo_actor", PPOActorInterface)

--- a/realhf/impl/model/nn/real_llm_api.py
+++ b/realhf/impl/model/nn/real_llm_api.py
@@ -875,7 +875,7 @@ def make_real_model(
     tokenizer = model_api.load_hf_tokenizer(model_path)
     mconfig = getattr(ReaLModel, f"config_from_{hf_model_family}")(
         model_path=model_path,
-        is_critic=is_critic,
+        is_critic=is_critic or init_critic_from_actor,
     )
     m = ReaLModel(mconfig, dtype=dtype, device=device)
     m._instantiation_hooks.append(

--- a/realhf/search_engine/param_realloc.py
+++ b/realhf/search_engine/param_realloc.py
@@ -13,6 +13,7 @@ import realhf.base.constants as constants
 import realhf.base.topology as topology
 from realhf.api.core.config import ModelFamily, ModelName
 from realhf.api.core.model_api import ReaLModelConfig
+from realhf.base.topology import decompose_to_three_factors
 
 
 def bcast_cost(
@@ -105,17 +106,6 @@ def compute_cost(
         max_bcast_cnt = max(max_bcast_cnt, bcast_cnt)
 
     return max_cost
-
-
-def decompose_to_three_factors(n: int):
-    factors = []
-    for i in range(1, int(n ** (1 / 2)) + 1):
-        if n % i == 0:
-            for j in range(i, int((n // i) ** (1 / 2)) + 1):
-                if (n // i) % j == 0:
-                    k = (n // i) // j
-                    factors += list(set(itertools.permutations([i, j, k])))
-    return factors
 
 
 def dump_table(

--- a/realhf/system/buffer.py
+++ b/realhf/system/buffer.py
@@ -75,6 +75,11 @@ class _TensorDictSequenceBuffer:
             self.__has_keys[idx] = [
                 k in self.__storage[idx].sample.keys for k in self.__keys
             ]
+            if any(k not in self.__keys for k in self.__storage[idx].sample.keys):
+                logger.warning(
+                    f"Unexpected keys in the sample. Expected keys from all MFCDef: {self.__keys}."
+                    f"Keys in the current sample: {self.__storage[idx].sample.keys}"
+                )
 
     def _get_has_keys(self, indices):
         return self.__has_keys[indices, :]

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -472,7 +472,6 @@ class ModelWorker(worker_base.Worker):
                 )
                 return
             if not m._offloaded:
-                # TODO: we should offload during initialize as well
                 m.async_offload()
         else:
             raise NotImplementedError(f"Unknown hook {hook}.")

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -102,7 +102,6 @@ class ModelWorker(worker_base.Worker):
 
         self.data_consumers = self.config.model_rpcs[0].data_consumers
 
-        # NOTE: here worker_index is different from peer/ddp rank
         self.__worker_index = cfg.worker_info.worker_index
 
         torch.backends.cudnn.benchmark = cfg.cudnn_benchmark
@@ -110,8 +109,8 @@ class ModelWorker(worker_base.Worker):
 
         seeding.set_random_seed(cfg.seed)
 
-        # Reveal DDP identity of this worker to world.
-        gpu_utils.reveal_ddp_identity(
+        # Reveal process group identity of this worker to world.
+        gpu_utils.reveal_pg_identity(
             self.__experiment_name, self.__trial_name, self.__worker_index
         )
         self.__dist_env_resolved = False

--- a/realhf/system/worker_base.py
+++ b/realhf/system/worker_base.py
@@ -588,7 +588,9 @@ class Worker:
         self.__set_status(WorkerServerStatus.RUNNING)
 
     def pause(self):
-        self.logger.info("Pausing worker")
+        self.logger.info(
+            f"Pausing worker index {self.__worker_info.worker_index + 1} out of {self.__worker_info.worker_count}"
+        )
         self.__running = False
         self.__set_status(WorkerServerStatus.PAUSED)
 
@@ -598,10 +600,6 @@ class Worker:
     def exit(self):
         self.logger.info("Exiting worker")
         self._exit_hook(WorkerServerStatus.COMPLETED)
-        import torch.distributed as dist
-
-        if dist.is_initialized():
-            dist.destroy_process_group()
         self.__set_status(WorkerServerStatus.COMPLETED)
         self.__exiting = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ transformers==4.42.3
 networkx==3.3
 matplotlib
 tabulate
+aiofiles

--- a/tests/data/test_load_data.py
+++ b/tests/data/test_load_data.py
@@ -86,7 +86,7 @@ def _validate_dataset(cfg: config_api.DatasetAbstraction, tokenizer):
     dataset = data_api.make_dataset(
         cfg,
         seed=1,
-        ddp_rank=0,
+        dp_rank=0,
         world_size=1,
         tokenizer_or_tokenizer_name=tokenizer,
         experiment_name=uuid.uuid4(),


### PR DESCRIPTION
# Main Changes:

+ Add APIs to mock the data required by interfaces. Under the profiling mode, model workers will first pass the data sampled from the dataset to the mock method, then the created artifacts will be passed to the real interface that needs profiling.

+ Fix the approach to computing CUDAKernelTime. Now the kernel time is collected from chrome traces, instead of `key_averages`. In this way, we can take the overlap between computation and communication into consideration.

+ Modify the controller, model worker, and master worker, such that we can run multiple experiment setups under the same experiment name and trial name without relaunch.

# Refactors

+ Remove unused `realhf.base.name_resolve` names.

+ Rename `ddp` to `pg`, referring to "process group", rather than "distributed data parallel".

