### PR TITLE
[Patch Fix] Support arbitrary symmetric allocations and fix MFC time log in workers

### DIFF
--- a/examples/scripts/local/ppo_symm.sh
+++ b/examples/scripts/local/ppo_symm.sh
@@ -1,0 +1,85 @@
+# MODEL_FAMILY specifies how the pretrained checkpoint is loaded, e.g., as a LLaMA model or a GPT model.
+# You can specify different model families for the SFT and the RW model, but you need to
+# re-tokenize the sequences if necessary.
+MODEL_FAMILY=llama
+
+# SFT_MODEL_PATH and RW_MODEL_PATH are the saved SFT and RW checkpoints.
+# ReaL saves checkpoints with the same format as HuggingFace,
+# so you don't need to convert or split checkpoints explicitly.
+# You can also directly use the pre-trained HuggingFace checkpoint, but this
+# will not ensure the optimal algorithm performance.
+SFT_MODEL_PATH=/lustre/aigc/llm/checkpoints/fw/quickstart-sft/$MODEL_FAMILY-local-manual/default/epoch7epochstep5globalstep50/
+RW_MODEL_PATH=/lustre/aigc/llm/checkpoints/fw/quickstart-rw/$MODEL_FAMILY-ray-manual/default/epoch1epochstep10globalstep10/
+
+# Option 1: The experiment runs locally with subprocesses.
+MODE=local
+# Option 2: The experiment runs in a Ray cluster
+# MODE=ray
+# Option 3: The experiment runs in a SLURM + pyxis cluster
+# Using the slurm mode requires a cluster spec file
+# and setting CLUSTER_SPEC_PATH to the path of it.
+# MODE=slurm
+
+# `experiment_name` and `trial_name` can be arbitrary.
+# Logs and saved checkpoints will be indexed by them.
+EXP_NAME=quickstart-ppo
+TRIAL_NAME=$MODEL_FAMILY-$MODE-manual
+
+# When using the "manual" allocation mode, the user should specify the device allocation
+# and parallel strategies for each model function calls.
+# The number of GPUs is `n_nodes` * `n_gpus_per_node` (not set explictly here, defaults to 8).
+# We provide a template in the following command and the user can modify it according to
+# the specific model and the available GPUs.
+
+# The `ppo` subcommand specifies that this is a PPO experiment.
+# The `save_freq_steps` is set to `null` to disable saving checkpoints.
+# Enable it if you want to save checkpoints.
+# The `ppo` option is used to control the generation and PPO algorithm hyperparameters.
+# Note that the performance of PPO is sensitive to the the pre-trained model and hyperparameters.
+# It's the user's responsibility to tune them appropriately.
+# The allocation of model function calls is specified by a pattern `hostname:gpu_id1,gpu_id2,...`
+# for slicing GPUS of a single node, and `hostname1,hostname2` for multiple nodes.
+# Only 1, 2, 4, 8 GPUs on a single node or multiple complete nodes (e.g., 16, 24) are supported.
+# If the CLUSTER_SPEC_PATH is not set, `hostname`s are NODE01, NODE02, etc, otherwise it's the
+# hostname specified in this file. The `gpu_id`s are the GPU indices on the host,
+# from 0 to `n_gpus_per_node` (defaults to 8, can be changed) - 1.
+# Once allocations are all set, parallel strategies can be specified as long as the world size
+# equals to the number of GPUs in the allocation.
+
+# The following command shows an example of manual allocation on two nodes,
+# but it can be modified according to the specific model and the available GPUs.
+unset CLUSTER_SPEC_PATH
+python3 -m realhf.apps.quickstart ppo \
+    mode=$MODE \
+    experiment_name=$EXP_NAME \
+    trial_name=$TRIAL_NAME \
+    exp_ctrl.total_train_epochs=1 \
+    exp_ctrl.save_freq_steps=null \
+    actor.type._class=$MODEL_FAMILY \
+    actor.path=$SFT_MODEL_PATH \
+    actor.optimizer.lr_scheduler_type=constant \
+    actor.optimizer.lr=1e-4 \
+    actor.optimizer.warmup_steps_proportion=0.0 \
+    critic.type._class=$MODEL_FAMILY \
+    critic.type.is_critic=True \
+    critic.path=$RW_MODEL_PATH \
+    ref.type._class=$MODEL_FAMILY \
+    ref.path=$SFT_MODEL_PATH \
+    rew.type._class=$MODEL_FAMILY \
+    rew.type.is_critic=True \
+    rew.path=$RW_MODEL_PATH \
+    dataset.path=/lustre/fw/datasets/imdb/rl/ppo_prompt.jsonl \
+    dataset.max_prompt_len=128 \
+    dataset.train_bs_n_seqs=128 \
+    ppo.gen.max_new_tokens=512 \
+    ppo.gen.min_new_tokens=512 \
+    ppo.gen.top_p=0.9 ppo.gen.top_k=1000 \
+    ppo.ppo_n_minibatches=4 \
+    ppo.kl_ctl=0.1 \
+    ppo.value_eps_clip=0.2 \
+    ppo.reward_output_scaling=10.0 \
+    ppo.adv_norm=True ppo.value_norm=True \
+    allocation_mode=m2d2p2 \
+    actor_gen.n_mbs=2 \
+    actor_train.n_mbs=4 \
+    ref_inf.n_mbs=2

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -52,6 +52,10 @@ class GlobalMemoryBuffer:
             res.zero_()
         return res
 
+# 30 minutes. Transferring super-large batches via NCCL bcast
+# for the first time may consumer over 600 secs, which is the 
+# pytorch's default. Increase this value to 30 minutes.
+NCCL_DEFAULT_TIMEOUT = 1800  
 
 # constants in experiment instance scope
 MODEL_SAVE_ROOT = f"{cluster_spec.fileroot}/checkpoints/{getpass.getuser()}"

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 from collections import defaultdict
 from typing import *
+import datetime
 
 import numpy as np
 
@@ -56,7 +57,7 @@ class GlobalMemoryBuffer:
 # 30 minutes. Transferring super-large batches via NCCL bcast
 # for the first time may consumer over 600 secs, which is the
 # pytorch's default. Increase this value to 30 minutes.
-NCCL_DEFAULT_TIMEOUT = 1800
+NCCL_DEFAULT_TIMEOUT = datetime.timedelta(seconds=1800)
 
 # constants in experiment instance scope
 MODEL_SAVE_ROOT = f"{cluster_spec.fileroot}/checkpoints/{getpass.getuser()}"

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -52,10 +52,11 @@ class GlobalMemoryBuffer:
             res.zero_()
         return res
 
+
 # 30 minutes. Transferring super-large batches via NCCL bcast
-# for the first time may consumer over 600 secs, which is the 
+# for the first time may consumer over 600 secs, which is the
 # pytorch's default. Increase this value to 30 minutes.
-NCCL_DEFAULT_TIMEOUT = 1800  
+NCCL_DEFAULT_TIMEOUT = 1800
 
 # constants in experiment instance scope
 MODEL_SAVE_ROOT = f"{cluster_spec.fileroot}/checkpoints/{getpass.getuser()}"

--- a/realhf/base/constants.py
+++ b/realhf/base/constants.py
@@ -1,12 +1,12 @@
 # log format constants
 import contextlib
 import copy
+import datetime
 import getpass
 import os
 import pathlib
 from collections import defaultdict
 from typing import *
-import datetime
 
 import numpy as np
 

--- a/realhf/base/topology.py
+++ b/realhf/base/topology.py
@@ -6,6 +6,7 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 import torch.distributed as dist
 
 import realhf.base.logging as logging
+from realhf.base.constants import NCCL_DEFAULT_TIMEOUT
 
 logger = logging.getLogger("Topology")
 
@@ -19,7 +20,9 @@ def new_or_get_group(ranks: List[int], backend=None):
     global GLOBAL_PROCESS_GROUP_REGISTRY
     key = (ranks, backend)
     if key not in GLOBAL_PROCESS_GROUP_REGISTRY:
-        GLOBAL_PROCESS_GROUP_REGISTRY[key] = dist.new_group(ranks, backend=backend)
+        GLOBAL_PROCESS_GROUP_REGISTRY[key] = dist.new_group(
+            ranks, backend=backend, timeout=NCCL_DEFAULT_TIMEOUT
+        )
     return GLOBAL_PROCESS_GROUP_REGISTRY[key]
 
 

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -92,6 +92,8 @@ class CommonExperimentConfig(Experiment):
 
     - ``pipe_model``\: identical parallelization (like DSChat) with pipe+model parallelism. A world size under 8 will use tensor-model parallelism only.
 
+    - A regex pattern like ``d${DP}p${PP}m${TP}``\: a symmetric parallelization pattern with ${DP}-way data parallelism, ${PP}-way pipeline parallelism, and ${TP}-way model parallelism.
+
     :param experiment_name: Name of the experiment.
         Arbitrary string without "_" and "/", e.g., ``ultra-chat-llama``.
         Must be provided.

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -88,11 +88,11 @@ class CommonExperimentConfig(Experiment):
 
     - ``heuristic``\: allocate resources and configure parallel strategies with heuristic strategies previously obtained by search.
 
-    - ``pipe_data``\: identical parallelization (like DSChat) with pipe+data parallelism. A world size under 8 will use data parallelism only.
+    - ``pipe_data``\: identical parallelization (like DSChat) with pipe+data parallelism for all MFCs. A world size under 8 will use data parallelism only.
 
-    - ``pipe_model``\: identical parallelization (like DSChat) with pipe+model parallelism. A world size under 8 will use tensor-model parallelism only.
+    - ``pipe_model``\: identical parallelization (like DSChat) with pipe+model parallelism for all MFCs. A world size under 8 will use tensor-model parallelism only.
 
-    - A regex pattern like ``d${DP}p${PP}m${TP}``\: a symmetric parallelization pattern with ${DP}-way data parallelism, ${PP}-way pipeline parallelism, and ${TP}-way model parallelism.
+    - A regex pattern like ``d${DP}p${PP}m${TP}``\: identical parallelization for all MFCs with ${DP}-way data parallelism, ${PP}-way pipeline parallelism, and ${TP}-way model parallelism.
 
     :param experiment_name: Name of the experiment.
         Arbitrary string without "_" and "/", e.g., ``ultra-chat-llama``.

--- a/realhf/experiments/common/utils.py
+++ b/realhf/experiments/common/utils.py
@@ -1,4 +1,6 @@
 import collections
+import itertools
+import re
 from typing import *
 
 import numpy as np
@@ -177,3 +179,17 @@ def resolve_rpc_hooks(rpc_allocs: List[RPCAllocation]):
         ):
             rpc.add_post_hook(OffloadHook())
             logger.info(f"Add offload hook for rpc {rpc.name} for role {rpc.role}")
+
+
+def extract_symmetric_allocation(allocation_mode: str) -> Dict | None:
+    for x, y, z in itertools.permutations(["d", "m", "p"]):
+        pattern = rf"{x}(\d+){y}(\d+){z}(\d+)"
+        m = re.match(pattern, allocation_mode)
+        if not m:
+            continue
+        a, b, c = map(int, m.groups())
+        return {
+            "d": a,
+            "m": b,
+            "p": c,
+        }

--- a/realhf/impl/model/comm/data_transfer.py
+++ b/realhf/impl/model/comm/data_transfer.py
@@ -123,9 +123,9 @@ class DataTransferReceiverStep:
 
 
 def chunked_bcast(buf, src_rank, group, chunk_size_bytes=BCAST_CHUNK_SIZE_BYTES):
-    # Broadcasting super-large data may cause DistBackendError,
+    # Broadcasting super-large data for the first time may hang and cause DistBackendError,
     # which I believe is due to the limitation of PyTorch.
-    # Broadcasting in chunk instead. The chunk size is not well-tuned,
+    # Broadcast in chunk instead. The chunk size is not well-tuned,
     # and it's just a value that works for our experiments with bs 8192 and ctx 4096.
     shape = buf.shape
     chunk_size = chunk_size_bytes // buf.dtype.itemsize

--- a/realhf/impl/model/comm/global_comm.py
+++ b/realhf/impl/model/comm/global_comm.py
@@ -112,6 +112,7 @@ def setup_global_comm(
         rank=global_rank,
         init_method=ddp_init_address,
         backend=backend,
+        timeout=constants.NCCL_DEFAULT_TIMEOUT,
     )
     if torch.cuda.is_available():
         torch.cuda.set_device(

--- a/realhf/system/master_worker.py
+++ b/realhf/system/master_worker.py
@@ -367,7 +367,7 @@ def _attach_payloads_with_hooks(
     return payloads, mwids
 
 
-async def scatter_tensor_to_mws(
+async def _request_model_function_call(
     rpc: dfg.MFCDef,
     stream: request_reply_stream.NameResolvingRequestClient,
     msid2mwid: Dict[config_pkg.ModelShardID, int],
@@ -585,7 +585,7 @@ async def model_rpc_request_func(
             producer_mappings[names[0], k] = producer_mapping
 
         # send partitioned data to model workers
-        req_ids, other_req_ids = await scatter_tensor_to_mws(
+        req_ids, other_req_ids = await _request_model_function_call(
             rpc=rpc,
             stream=stream,
             msid2mwid=msid2mwid,

--- a/realhf/system/model_worker.py
+++ b/realhf/system/model_worker.py
@@ -119,9 +119,6 @@ class ModelWorker(worker_base.Worker):
 
         r = self.config.worker_info
 
-        # log info
-        self.__total_time = 0.01
-
         # recover info
         self.__recover_run = os.environ.get("REAL_RECOVER_RUN", "0") == "1"
         self.__recover_info = (
@@ -521,24 +518,6 @@ class ModelWorker(worker_base.Worker):
         else:
             handler_model_name = request.handler.model_name
 
-        # handle post hooks
-        if handled and len(request.post_hooks) > 0:
-            assert len(request.post_hooks) == len(request.post_hook_data)
-            self.__handle_one_rpc_hook(
-                request.post_hooks.pop(0), request.post_hook_data.pop(0)
-            )
-            self.__request_queue.put_nowait((request, data, True, res))
-            return
-
-        if handled and len(request.post_hooks) == 0:
-            self.__reply_queue.put_nowait((request, res))
-            # self.logger.info(f"Model worker {self.__worker_index} #{request.handler}# "
-            #                          f"finish handling request *{request.handle_name}*, "
-            #                          f"request_id {request.request_id}.")
-            sample_count = data.bs if isinstance(data, data_api.SequenceSample) else 1
-            self.__request_sample_size[request.request_id] = sample_count
-            return
-
         assert not handled and res is None, (
             handled,
             res,
@@ -639,6 +618,7 @@ class ModelWorker(worker_base.Worker):
                             f"Model worker {self.__worker_index} cleared cache in {et-st:.4f}s"
                         )
                 dump_tmark_db(self.__worker_index)
+                res = request_reply_stream.NoResponse()
             ############## computation function calls ##############
             elif request.handle_name in ["inference", "generate", "train_step"]:
                 res = self.__handle_model_function_calls(request, data)
@@ -667,7 +647,15 @@ class ModelWorker(worker_base.Worker):
                     f" in ${time.perf_counter() - tik:.4f}$s"
                 )
 
-        self.__request_queue.put_nowait((request, data, True, res))
+        # Handle all post hooks right after the main computation
+        if len(request.post_hooks) > 0:
+            assert len(request.post_hooks) == len(request.post_hook_data)
+            for hook, hook_data in zip(request.post_hooks, request.post_hook_data):
+                self.__handle_one_rpc_hook(hook, hook_data)
+
+        self.__reply_queue.put_nowait((request, res))
+        sample_count = data.bs if isinstance(data, data_api.SequenceSample) else 1
+        self.__request_sample_size[request.request_id] = sample_count
 
     @contextlib.contextmanager
     def __maybe_profile_rpc(self, rpc: dfg.MFCDef):
@@ -832,6 +820,9 @@ class ModelWorker(worker_base.Worker):
 
         batch_size = sample_size = 0
         for request, res in ready_to_post:
+            # For some requests, do not respond to the master worker.
+            if isinstance(res, request_reply_stream.NoResponse):
+                continue
             request: request_reply_stream.Payload
             reply = request_reply_stream.Payload(
                 handler="master",
@@ -864,7 +855,7 @@ class ModelWorker(worker_base.Worker):
 
     @cuda_tmark("receive_request", CUDATimeMarkType.misc)
     def maybe_receive_requests(self):
-        for _ in range(8):
+        for _ in range(16):
             self.__maybe_receive_one_request()
 
         while len(self.__request_cache) > 0:
@@ -889,30 +880,25 @@ class ModelWorker(worker_base.Worker):
         if self.__has_dataset:
             self.prefetch_from_dataset()
 
-        st = time.monotonic()
         self.maybe_receive_requests()
 
         # NOTE: We ensure that all model workers have the same set of requests
         # at any time through a TCP-like protocol, i.e., req -> ack -> syn -> resp.
         # Each request is composed of pre-hooks, the main request, and post-hooks.
         # We execute all pre-hooks first because they involve data transfer
-        # among workers. Then, we round-robinly execute hooks and requests.
-        # These are designed to prevent mutual blocking when different requests
-        # are handled in different but intersected sets of model workers.
-        # E.g., If we have a request A and a request B, the execution order will be
-        # A.pre_hook -> B.pre_hook -> A -> B -> A.post_hook -> B.post_hook.
+        # among workers. Executing them first avoids blocking MFCs that require
+        # data from the same set of GPUs but are executed on disjoint GPUs.
         self.handle_all_pre_hooks()
-        for _ in range(16):
-            try:
-                request, data, handled, res = self.__request_queue.get_nowait()
-                self.model_poll_step(request, data, handled, res)
-            except queue.Empty:
-                break
+
+        # Execute one MFC them immediately return the result, such that
+        # we can correctly log the time consumption in the master worker.
+        try:
+            request, data, handled, res = self.__request_queue.get_nowait()
+            self.model_poll_step(request, data, handled, res)
+        except queue.Empty:
+            pass
 
         r = self.maybe_post_responses()
-
-        t = time.monotonic() - st
-        self.__total_time += t
         return r
 
     def __recover_save(self):
@@ -970,7 +956,7 @@ class ModelWorker(worker_base.Worker):
         # All-gather hostname, gpu ID, and stats.
         hostname = socket.gethostname()
         hostname_len = len(hostname)
-        assert hostname_len < 64, "hostname should have more than 64 chars"
+        assert hostname_len < 64, "hostname should not have more than 64 chars"
         # Encode hostnames into long.
         hostname_np = np.fromstring(
             hostname + "x" * (64 - len(hostname)), dtype=np.int64

--- a/realhf/system/request_reply_stream.py
+++ b/realhf/system/request_reply_stream.py
@@ -25,6 +25,10 @@ class NoMessage(Exception):
     pass
 
 
+class NoResponse:
+    pass
+
+
 @dataclasses.dataclass
 class Payload:
     handler: Union[system_api.ModelShardID, str]


### PR DESCRIPTION
# New Features

+ Support arbitrary symmetric parallelization via regex. Now the system can parse strings like "d4m1p2" or "m1p2d5" and apply this parallel strategy to all MFCs.

# Patch Fixes

+ Increase the default timeout of NCCL process groups to 1800 secs. Transferring extremely large batches for the first time may consumer over 600 secs, which is the default timeout of pytorch.

+ Offload models upon initialization to save the memory for the first MFC.

+ A more accurate record of the MFC completion time. The model worker will return responses immediately to the master worker upon an MFC's completion.

+ Modify the naming of helper functions in the master worker to avoid confusion.