### PR TITLE
Omit destroying the NCCLProcessGroup when experiment completes.

### DIFF
--- a/realhf/base/topology.py
+++ b/realhf/base/topology.py
@@ -34,7 +34,9 @@ def destroy_all_comm_groups():
     for group in GLOBAL_PROCESS_GROUP_REGISTRY.values():
         dist.destroy_process_group(group)
     GLOBAL_PROCESS_GROUP_REGISTRY = {}
-    dist.destroy_process_group()
+    # Destroying the default group will raise an error
+    # for the latest pytorch release. Omit it as a workaround.
+    # dist.destroy_process_group()
 
 
 def decompose_to_three_factors(n: int) -> List[Tuple[int, int, int]]:

--- a/realhf/impl/model/comm/global_comm.py
+++ b/realhf/impl/model/comm/global_comm.py
@@ -121,9 +121,10 @@ def setup_global_comm(
     # This environment variable is used by DeepSpeed.
     os.environ["LOCAL_RANK"] = "0"
 
-    torch.distributed.init_process_group(
-        **torch_dist_kwargs, group_name=gpu_utils.GLOBAL_PROCESS_GROUP_NAME
-    )
+    if not torch.distributed.is_initialized():
+        torch.distributed.init_process_group(
+            **torch_dist_kwargs, group_name=gpu_utils.GLOBAL_PROCESS_GROUP_NAME
+        )
 
     model_groups = {}
     for model_name, ranks in mw_ranks.items():


### PR DESCRIPTION
It fixes an issue with the latest pytorch release.